### PR TITLE
allow properties with hyphens in them

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,9 +160,10 @@ a property:
 
 #. The setter method (``set`` + ``ucwords($propertyname)``) is inspected.
 
-   Underscores make the next letter uppercase, which means that
-   for a JSON property ``foo_bar_baz`` a setter method of
-   ``setFooBarBaz`` is used.
+   Underscores and hyphens (-) make the next letter uppercase,
+   examples:
+       - property: ``foo_bar_baz`` setter: ``setFooBarBaz``
+       - property: ``foo-bar-baz`` setter: ``setFooBarBaz``
 
    #. If it has a type hint in the method signature, this type used::
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -125,6 +125,9 @@ class JsonMapper
         $strNs = $rc->getNamespaceName();
         $providedProperties = array();
         foreach ($json as $key => $jvalue) {
+
+            $key = $this->getSafeName($key);
+
             $providedProperties[$key] = true;
 
             // Store the property inspection results so we don't have to do it
@@ -331,6 +334,9 @@ class JsonMapper
     public function mapArray($json, $array, $class = null)
     {
         foreach ($json as $key => $jvalue) {
+
+            $key = $this->getSafeName($key);
+
             if ($class === null) {
                 $array[$key] = $jvalue;
             } else if ($this->isFlatType(gettype($jvalue))) {
@@ -372,9 +378,8 @@ class JsonMapper
     protected function inspectProperty(ReflectionClass $rc, $name)
     {
         //try setter method first
-        $setter = 'set' . str_replace(
-            ' ', '', ucwords(str_replace('_', ' ', $name))
-        );
+        $setter = 'set' . $this->getUppercaseName($name);
+
         if ($rc->hasMethod($setter)) {
             $rmeth = $rc->getMethod($setter);
             if ($rmeth->isPublic()) {
@@ -440,6 +445,34 @@ class JsonMapper
 
         //no setter, no property
         return array(false, null, null);
+    }
+
+    /**
+     * removes - and _ and makes the next letter that uppercase
+     * 
+     * @param $name
+     * @return mixed
+     */
+    private function getUppercaseName($name)
+    {
+        return str_replace(
+            ' ', '', ucwords(str_replace(array('_', '-'), ' ', $name))
+        );
+    }
+
+    /**
+     * since hyphens cant be used in variables we have to uppercase them
+     *
+     * @param $name
+     * @return mixed
+     */
+    private function getSafeName($name)
+    {
+        if (strpos($name, '-') !== false) {
+            $name = $this->getUppercaseName($name);
+        }
+
+        return $name;
     }
 
     /**

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -450,10 +450,11 @@ class JsonMapper
     /**
      * removes - and _ and makes the next letter that uppercase
      * 
-     * @param $name
+     * @param string $name property name
+     *
      * @return mixed
      */
-    private function getUppercaseName($name)
+    protected function getUppercaseName($name)
     {
         return str_replace(
             ' ', '', ucwords(str_replace(array('_', '-'), ' ', $name))
@@ -463,10 +464,11 @@ class JsonMapper
     /**
      * since hyphens cant be used in variables we have to uppercase them
      *
-     * @param $name
+     * @param string $name property name
+     *
      * @return mixed
      */
-    private function getSafeName($name)
+    protected function getSafeName($name)
     {
         if (strpos($name, '-') !== false) {
             $name = $this->getUppercaseName($name);

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -85,6 +85,12 @@ class JsonMapperTest_Simple
     public $under_score;
 
     /**
+     * Variable name with hyphen (-)
+     * @var string
+     */
+    public $hyphenValue;
+
+    /**
      * @var
      */
     public $empty;
@@ -126,6 +132,11 @@ class JsonMapperTest_Simple
     public function setUnderScoreSetter($v)
     {
         $this->internalData['under_score_setter'] = $v;
+    }
+
+    public function setHyphenValueSetter($v)
+    {
+        $this->internalData['hyphen-value-setter'] = $v;
     }
 
     public function setSetterPreferredOverProperty($v)

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -198,6 +198,7 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('f', $sn->under_score);
     }
 
+
     /**
      * Variable with an underscore and a setter method
      */
@@ -214,6 +215,41 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'blubb', $sn->internalData['under_score_setter']
         );
+    }
+
+    /**
+     * Variable with hyphen (-)
+     */
+    public function testMapSimpleHyphen()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"hyphen-value":"test"}'),
+            new JsonMapperTest_Simple()
+        );
+
+        $this->assertInternalType('string', $sn->hyphenValue);
+        $this->assertEquals('test', $sn->hyphenValue);
+
+    }
+
+    /**
+     * Variable with hyphen and a setter method
+     */
+    public function testMapSimpleHyphenSetter()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"hyphen-value-setter":"blubb"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType(
+            'string', $sn->internalData['hyphen-value-setter']
+        );
+        $this->assertEquals(
+            'blubb', $sn->internalData['hyphen-value-setter']
+        );
+
     }
 }
 ?>


### PR DESCRIPTION
Currently it is not possible to use json properties with hyphens (-).

This PR fixes this issue by making sure that properties with hyphens are uppercased when looking for propertynames and setters.

