### PR TITLE
Add functionality to optionally turn off the nullable checks

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -67,6 +67,14 @@ class JsonMapper
     public $bStrictObjectTypeChecking = false;
 
     /**
+     * Throw an exception, if null value is found
+     * but the type of attribute does not allow nulls.
+     *
+     * @var bool
+     */
+    public $bStrictNullTypes = true;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -173,7 +181,7 @@ class JsonMapper
                 continue;
             }
 
-            if ($this->isNullable($type)) {
+            if ($this->isNullable($type) || !$this->bStrictNullTypes) {
                 if ($jvalue === null) {
                     $this->setProperty($object, $accessor, null);
                     continue;

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -269,6 +269,20 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Exception is not thrown when a non-nullable object has null value
+     * but strict nullable checks are turned off
+     */
+    public function testNonNullableArrayObjectWithLooseNullChecks()
+    {
+        $jm = new JsonMapper();
+        $jm->bStrictNullTypes = false;
+        $sn = $jm->map(
+            json_decode('{"pArrayObject": null}'),
+            new JsonMapperTest_Array()
+        );
+    }
+
+    /**
      * The TYPO3 autoloader breaks if we autoload a class with a [ or ]
      * in its name.
      *


### PR DESCRIPTION
## What it does?

This PR adds a property `bStrictNullTypes` which if `true` will not throw `JSON property abc must not be NULL` exception on any null values which are not nullable.

## Problem

I have been using this to map the requests and responses in the APIs and I have found it quite common that the APIs 

- While making the requests, a huge dataset could be sent while only two or three fields are required and most of the fields are optional. And one has to make each and every optional field in the entity/class nullable so that the mapper may not throw exception or extend it to turn the null checks off as this "null-vs-required" validation lies in the application logic any ways.

- In the response, sometimes you are not sure about what will be returned for the optional fields i.e. sometimes they may return null and others may not return the field at all (e.g. [Checkout](https://www.checkout.com/) is one of them).