### PR TITLE
Map private properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -373,8 +373,8 @@ an exception when ``$bExceptionOnMissingData`` is activated:
     $jm->map(...);
 
 
-Private properties
-------------------
+Private properties and functions
+--------------------------------
 If you want immutable objects without public accessors like this:
 
 .. code:: php

--- a/README.rst
+++ b/README.rst
@@ -373,6 +373,27 @@ an exception when ``$bExceptionOnMissingData`` is activated:
     $jm->map(...);
 
 
+Private properties
+------------------
+If you want immutable objects without public accessors like this:
+
+.. code:: php
+
+    /**
+     * @var string
+     */
+    private $someDatum;
+
+You can allow mapping to private properties and functions by
+setting the ``$bAllowPrivatePropertiesMapping`` to true:
+
+.. code:: php
+
+    $jm = new JsonMapper();
+    $jm->bAllowPrivatePropertiesMapping = true;
+    $jm->map(...);
+
+
 Simple types instead of objects
 -------------------------------
 When a variable's type is a class and JSON data is a simple type

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -75,6 +75,13 @@ class JsonMapper
     public $bStrictNullTypes = true;
 
     /**
+     * Allow mapping of private and proteted properties.
+     *
+     * @var boolean
+     */
+    public $bAllowPrivatePropertiesMapping = false;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -168,7 +175,7 @@ class JsonMapper
             }
 
             if ($accessor === null) {
-                if ($this->bExceptionOnUndefinedProperty) {
+                if ($this->bExceptionOnUndefinedProperty && !$this->bAllowPrivatePropertiesMapping) {
                     throw new JsonMapper_Exception(
                         'JSON property "' . $key . '" has no public setter method'
                         . ' in object of type ' . $strClassName
@@ -421,7 +428,7 @@ class JsonMapper
         } else {
             //case-insensitive property matching
             $rprop = null;
-            foreach ($rc->getProperties(ReflectionProperty::IS_PUBLIC) as $p) {
+            foreach ($rc->getProperties() as $p) {
                 if ((strcasecmp($p->name, $name) === 0)) {
                     $rprop = $p;
                     break;
@@ -429,7 +436,7 @@ class JsonMapper
             }
         }
         if ($rprop !== null) {
-            if ($rprop->isPublic()) {
+            if ($rprop->isPublic() || $this->bAllowPrivatePropertiesMapping) {
                 $docblock    = $rprop->getDocComment();
                 $annotations = $this->parseAnnotations($docblock);
 
@@ -489,16 +496,19 @@ class JsonMapper
      * Checks if the setter or the property are public are made before
      * calling this method.
      *
-     * @param object $object   Object to set property on
-     * @param object $accessor ReflectionMethod or ReflectionProperty
-     * @param mixed  $value    Value of property
+     * @param object $object Object to set property on
+     * @param ReflectionMethod|ReflectionProperty $accessor
+     * @param mixed $value Value of property
      *
      * @return void
      */
     protected function setProperty(
         $object, $accessor, $value
     ) {
-        if ($accessor instanceof ReflectionProperty) {
+        if ($this->bAllowPrivatePropertiesMapping && ($accessor->isPrivate() || $accessor->isProtected())) {
+            $accessor->setAccessible(true);
+            $accessor->setValue($object, $value);
+        } else if ($accessor instanceof ReflectionProperty) {
             $object->{$accessor->getName()} = $value;
         } else {
             $object->{$accessor->getName()}($value);

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -150,6 +150,9 @@ class JsonMapper
                     = $this->inspectProperty($rc, $key);
             }
 
+            /** bool $accessor $hasProperty */
+            /** \ReflectionMethod|\ReflectionProperty|null $accessor */
+            /** string|null $type */
             list($hasProperty, $accessor, $type)
                 = $this->arInspectedClasses[$strClassName][$key];
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -501,9 +501,9 @@ class JsonMapper
      * Checks if the setter or the property are public are made before
      * calling this method.
      *
-     * @param object $object    Object to set property on
-     * @param object $accessor  ReflectionMethod or ReflectionProperty
-     * @param mixed  $value     Value of property
+     * @param object $object   Object to set property on
+     * @param object $accessor ReflectionMethod or ReflectionProperty
+     * @param mixed  $value    Value of property
      *
      * @return void
      */

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -178,7 +178,9 @@ class JsonMapper
             }
 
             if ($accessor === null) {
-                if ($this->bExceptionOnUndefinedProperty && !$this->bAllowPrivatePropertiesMapping) {
+                if ($this->bExceptionOnUndefinedProperty
+                    && !$this->bAllowPrivatePropertiesMapping
+                ) {
                     throw new JsonMapper_Exception(
                         'JSON property "' . $key . '" has no public setter method'
                         . ' in object of type ' . $strClassName
@@ -499,16 +501,18 @@ class JsonMapper
      * Checks if the setter or the property are public are made before
      * calling this method.
      *
-     * @param object $object Object to set property on
-     * @param ReflectionMethod|ReflectionProperty $accessor
-     * @param mixed $value Value of property
+     * @param object $object    Object to set property on
+     * @param object $accessor  ReflectionMethod or ReflectionProperty
+     * @param mixed  $value     Value of property
      *
      * @return void
      */
     protected function setProperty(
         $object, $accessor, $value
     ) {
-        if ($this->bAllowPrivatePropertiesMapping && ($accessor->isPrivate() || $accessor->isProtected())) {
+        if ($this->bAllowPrivatePropertiesMapping
+            && ($accessor->isPrivate() || $accessor->isProtected())
+        ) {
             $accessor->setAccessible(true);
             $accessor->setValue($object, $value);
         } else if ($accessor instanceof ReflectionProperty) {

--- a/tests/JsonMapperTest/PrivateWithSetter.php
+++ b/tests/JsonMapperTest/PrivateWithSetter.php
@@ -46,5 +46,21 @@ class PrivateWithSetter
     {
         return $this->privateProperty;
     }
+
+    /**
+     * @return int
+     */
+    public function getPrivateNoSetter()
+    {
+        return $this->privateNoSetter;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPrivatePropertyPrivateSetter()
+    {
+        return $this->privatePropertyPrivateSetter;
+    }
 }
 ?>

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -245,6 +245,21 @@ class OtherTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(empty($logger->log));
     }
 
+    public function testPrivatePropertyWithNoSetterButAllowed()
+    {
+        $jm = new JsonMapper();
+        $jm->bAllowPrivatePropertiesMapping = true;
+        $jm->bExceptionOnUndefinedProperty = true;
+        $logger = new JsonMapperTest_Logger();
+        $jm->setLogger($logger);
+
+        $json   = '{"privateNoSetter" : 1}';
+        $result = $jm->map(json_decode($json), new PrivateWithSetter());
+
+        $this->assertEquals(1, $result->getPrivateNoSetter());
+        $this->assertTrue(empty($logger->log));
+    }
+
     /**
      * @expectedException        JsonMapper_Exception
      * @expectedExceptionMessage JSON property "privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter
@@ -258,6 +273,20 @@ class OtherTest extends \PHPUnit_Framework_TestCase
 
         $json   = '{"privatePropertyPrivateSetter" : 1}';
         $result = $jm->map(json_decode($json), new PrivateWithSetter());
+    }
+
+    public function testPrivatePropertyWithPrivateSetterButAllowed()
+    {
+        $jm = new JsonMapper();
+        $jm->bAllowPrivatePropertiesMapping = true;
+        $jm->bExceptionOnUndefinedProperty = true;
+        $logger = new JsonMapperTest_Logger();
+        $jm->setLogger($logger);
+
+        $json   = '{"privatePropertyPrivateSetter" : 1}';
+        $result = $jm->map(json_decode($json), new PrivateWithSetter());
+
+        $this->assertEquals(1, $result->getPrivatePropertyPrivateSetter());
     }
 
     public function testSetterIsPreferredOverProperty()


### PR DESCRIPTION
Added the ability to map private properties. It is set to disabled by default to not break backwards compatibility or introduce errors in existing code bases.

Tests and documentation added. 