### PR TITLE
Add ClassName to exception message when null is not allowed.

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -197,7 +197,7 @@ class JsonMapper
                 $type = $this->removeNullable($type);
             } else if ($jvalue === null) {
                 throw new JsonMapper_Exception(
-                    'JSON property "' . $key . '" must not be NULL'
+                    'JSON property "' . $key . '" in class "' . $strClassName . '"" must not be NULL'
                 );
             }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -197,7 +197,8 @@ class JsonMapper
                 $type = $this->removeNullable($type);
             } else if ($jvalue === null) {
                 throw new JsonMapper_Exception(
-                    'JSON property "' . $key . '" in class "' . $strClassName . '" must not be NULL'
+                    'JSON property "' . $key . '" in class "'
+                    . $strClassName . '" must not be NULL'
                 );
             }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -197,7 +197,7 @@ class JsonMapper
                 $type = $this->removeNullable($type);
             } else if ($jvalue === null) {
                 throw new JsonMapper_Exception(
-                    'JSON property "' . $key . '" in class "' . $strClassName . '"" must not be NULL'
+                    'JSON property "' . $key . '" in class "' . $strClassName . '" must not be NULL'
                 );
             }
 

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -257,7 +257,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
      * An ArrayObject which may not be null but is.
      *
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pArrayObject" must not be NULL
+     * @expectedExceptionMessage JSON property "pArrayObject" in class "JsonMapperTest_Array" must not be NULL
      */
     public function testArrayObjectInvalidNull()
     {

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -148,7 +148,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
      * Test for "@var object" with null value
      *
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pValueObject" must not be NULL
+     * @expectedExceptionMessage JSON property "pValueObject" in class "JsonMapperTest_Object" must not be NULL
      */
     public function testObjectInvalidNull()
     {


### PR DESCRIPTION
Other exception messages have classname in them so i think this one should contain classname too. It makes debugging easier when u have nested objects.