### PR TITLE
Coded Feature Request for Issue #77

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ php:
   - 5.6
   - 7
   - 7.1
-  - hhvm
 
 before_script:
   - composer install --no-interaction --prefer-source --dev
   - phpenv rehash
 script:
   - cd tests
-  - phpunit --coverage-text .
+  - ./../vendor/bin/phpunit --coverage-text .
   - cd ..
   - ./vendor/bin/phpcs --standard=PEAR src/

--- a/README.rst
+++ b/README.rst
@@ -311,6 +311,30 @@ During development, APIs often change.
 To get notified about such changes, JsonMapper can be configured to
 throw exceptions in case of either missing or yet unknown data.
 
+Property Setters Validation
+---------------------------
+When JsonMapper sees that a setter returns a boolean with ``false``,
+it will throw an Exception by settings ``$bExceptionOnFalseSetter``:
+
+.. code:: php
+
+    $jm = new JsonMapper();
+    $jm->bExceptionOnFalseSetter = true;
+    $jm->map(...);
+
+An example of the situation is:
+
+.. code:: php
+
+    public $myProperty = 0;
+
+    public function setMyProperty(int $value) {
+         if(database()->count(table, $value) == 0) {
+            return false;
+         }
+
+         $this->myProperty = $value;
+    }
 
 Unknown properties
 ------------------

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -82,6 +82,18 @@ class JsonMapper
     public $bIgnoreVisibility = false;
 
     /**
+     * Throw an exception if the value set to a property
+     * by a setter it's null.
+     *
+     * eg.: setId ( return false );
+     *
+     * Usable on validation methods
+     *
+     * @var bool
+     */
+    public $bExceptionOnFalseSetter = false;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -505,6 +517,7 @@ class JsonMapper
      * @param mixed  $value    Value of property
      *
      * @return void
+     * @throws JsonMapper_Exception
      */
     protected function setProperty(
         $object, $accessor, $value
@@ -516,7 +529,15 @@ class JsonMapper
             $accessor->setValue($object, $value);
         } else {
             //setter method
-            $accessor->invoke($object, $value);
+            $returnValue = $accessor->invoke($object, $value);
+
+            // check if the return value of the setter is false
+            if($this->bExceptionOnFalseSetter && $returnValue === false) {
+                throw new JsonMapper_Exception(
+                    'JSON setter ' . $object . ' has boolean with false return value, ' .
+                    'with flag ExceptionOnNullableSetter, so an exception was thrown.'
+                );
+            }
         }
     }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -532,10 +532,10 @@ class JsonMapper
             $returnValue = $accessor->invoke($object, $value);
 
             // check if the return value of the setter is false
-            if($this->bExceptionOnFalseSetter && $returnValue === false) {
+            if ($this->bExceptionOnFalseSetter && $returnValue === false) {
                 throw new JsonMapper_Exception(
-                    'JSON setter ' . $object . ' has boolean with false return value, ' .
-                    'with flag ExceptionOnNullableSetter, so an exception was thrown.'
+                    'JSON setter ' . $object . ' has boolean return value, ' .
+                    'with flag ExceptionOnFalseSetter, so an exception was thrown.'
                 );
             }
         }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,7 +5,6 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestSize="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
-         checkForUnintentionallyCoveredCode="true"
 >
     <filter>
         <whitelist>


### PR DESCRIPTION
Feature Request based on Issue #77 proposal.

Where you can create Exceptions for `fluent setters` or `validator setters`, those validate if the input `data/argument` match a specific logic process/algorithm defined by the developer. And not only the simple variable type mapping that JsonMapper provides.

Good for what Models have as purpose, validate their own logic and set data.