### PR TITLE
Th add use support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "netresearch/jsonmapper",
+    "name": "spysystem/jsonmapper",
     "description": "Map nested JSON structures onto PHP classes",
     "license": "OSL-3.0",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/cweiske/jsonmapper/issues"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*",
+        "phpunit/phpunit": "5.7.*",
         "squizlabs/php_codesniffer": "~1.5"
     }
 }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -112,12 +112,23 @@ class JsonMapper
     protected $arInspectedClasses = array();
 
     /**
+     * Runtime cache for use clauses. Consists of an array of arrays, where the index for the first level is
+     * the full class name. Each sub-array will contain the "use" clauses found on the file regarding that
+     * class. This expects that the class respects PSR-1, which means one single class per file, and thus one
+     * single namespace. http://www.php-fig.org/psr/psr-1/#namespace-and-class-names
+     *
+     * @var string[][]
+     */
+    protected $arrUseClauses = [];
+
+    /**
      * Map data all data in $json into the given $object instance.
      *
      * @param object $json   JSON object structure from json_decode()
      * @param object $object Object to map $json data into
      *
      * @return object Mapped object is returned.
+     * @throws JsonMapper_Exception
      * @see    mapArray()
      */
     public function map($json, $object)
@@ -403,11 +414,11 @@ class JsonMapper
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
                     $pclass = $rparams[0]->getClass();
-                    $nullability = '';
-                    if ($rparams[0]->allowsNull()) {
-                        $nullability = '|null';
-                    }
                     if ($pclass !== null) {
+                        $nullability = '';
+                        if ($rparams[0]->allowsNull()) {
+                            $nullability = '|null';
+                        }
                         return array(
                             true, $rmeth,
                             '\\' . $pclass->getName() . $nullability
@@ -422,6 +433,9 @@ class JsonMapper
                     return array(true, $rmeth, null);
                 }
                 list($type) = explode(' ', trim($annotations['param'][0]));
+
+                $type = $this->getFullyQualifiedType($rc, $type);
+
                 return array(true, $rmeth, $type);
             }
         }
@@ -451,6 +465,8 @@ class JsonMapper
                 //support "@var type description"
                 list($type) = explode(' ', $annotations['var'][0]);
 
+                $type = $this->getFullyQualifiedType($rc, $type);
+
                 return array(true, $rprop, $type);
             } else {
                 //no setter, private property
@@ -460,6 +476,115 @@ class JsonMapper
 
         //no setter, no property
         return array(false, null, null);
+    }
+
+
+    /**
+     * Splits the $type string from the phpdoc, and finds the FQN for each type found
+     *
+     * @param ReflectionClass $rc
+     * @param string          $type
+     *
+     * @return string
+     */
+    protected function getFullyQualifiedType(ReflectionClass $rc, string $type)
+    {
+        $arrTypes = [];
+        $arrMatch = [];
+        foreach(explode('|', $type) as $strType) {
+            $strArraySection = '';
+            if(preg_match('/(.*?)(\[.*\])$/', $strType, $arrMatch) === 1) {
+                $strType = $arrMatch[1];
+                $strArraySection = $arrMatch[2];
+            }
+            $strFQNType = $this->getFQN($rc, $strType);
+            if($strArraySection !== '') {
+                if(preg_match('/^\[([\w]+)\]$/', $strArraySection, $arrMatch) === 1) {
+                    $strArraySection = '['.$this->getFQN($rc, $arrMatch[1]).']';
+                }
+            }
+            $arrTypes[] = $strFQNType.$strArraySection;
+        }
+        return implode('|', $arrTypes);
+
+
+    }
+
+    /**
+     * Gets the FQN for a type
+     *
+     * @param ReflectionClass $rc
+     * @param string          $strType
+     *
+     * @return string
+     */
+    protected function getFQN(ReflectionClass $rc, string $strType)
+    {
+        # If type starts with \, no need to append namespaces on it
+        if (strpos($strType, '\\') === 0) {
+            return $strType;
+        }
+        $arrUseClauses = $this->getUseClauses($rc);
+
+        if (count($arrUseClauses) === 0) {
+            return $strType;
+        }
+
+        # If there is a perfect match for the type within the use clauses, prepend a \ and return it -
+        # this will guarantee that we get the correct FQN for it, even if it belongs to the root namespace
+        if (array_key_exists($strType, $arrUseClauses)) {
+            return '\\' . $strType;
+        }
+
+        # If the type contains a relative qualified name, we need to find the first part of if within the 'use'
+        # clauses. To do that, we take the first sub-path of the type and search it within the use clauses. This
+        # should return exactly one match, since PHP does not allow ambiguous class names.
+        if (strpos($strType, '\\') !== false) {
+            # Gets first sub-path
+            $arrExplodedType = explode('\\', $strType, 2);
+            $strNSSubPath = $arrExplodedType[0];
+            # Get use clause that end with the found sub-path (There can be only one! #highlanderfeelings)
+            $arrMatchingUseClauses = preg_grep('/^(.*\\\\' . $strNSSubPath . '|' . $strNSSubPath . ')$/', $arrUseClauses);
+            if (count($arrMatchingUseClauses) === 1) {
+                return '\\' . preg_replace('/(.*)' . $strNSSubPath . '$/', '$1', reset($arrMatchingUseClauses)) . $strType;
+            }
+        } else {
+            # The last check against use clauses is when type is a SFQN and its FQN is in the use clauses:
+            $arrMatchingUseClauses = preg_grep('/\\\\'.$strType.'$/', $arrUseClauses);
+            if (count($arrMatchingUseClauses) === 1) {
+                return '\\'.reset($arrMatchingUseClauses);
+            }
+        }
+
+        # If nothing else was triggered, simply return the unchanged type
+        return $strType;
+    }
+
+    /**
+     * Finds all "use" clauses inside the class file, and returns a string[] with the found namespace names
+     * @param ReflectionClass $rc
+     *
+     * @return string[]
+     */
+    protected function getUseClauses(ReflectionClass $rc)
+    {
+        $strClassName = $rc->getName();
+        if (!array_key_exists($strClassName, $this->arrUseClauses)) {
+
+            $arrLines = file($rc->getFileName(), FILE_SKIP_EMPTY_LINES|FILE_IGNORE_NEW_LINES);
+
+            if ($arrLines && count($arrLines)) {
+                $arrUseLines = preg_grep('/^\s*use\s+[\w\\\\]+;/', $arrLines);
+
+                # strip out the 'use ' part
+                $this->arrUseClauses[$strClassName] = preg_replace('/(^\s*use\s+)([\w\\\\]+);/', '$2', $arrUseLines);
+
+                # makes keys match values, so that $arr[x] = x;
+                $this->arrUseClauses[$strClassName] = array_combine($this->arrUseClauses[$strClassName], $this->arrUseClauses[$strClassName]);
+            }
+        }
+
+        return $this->arrUseClauses[$strClassName];
     }
 
     /**

--- a/tests/namespacetest/NamespaceWithUseClauseTest.php
+++ b/tests/namespacetest/NamespaceWithUseClauseTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace namespacetest;
+use JsonMapper_Exception;
+
+require_once __DIR__ . '/Unit.php';
+require_once __DIR__ . '/UnitDataWithUseClause.php';
+require_once __DIR__ . '/model/MyArrayObject.php';
+require_once __DIR__ . '/model/User.php';
+require_once __DIR__ . '/model/UserList.php';
+require_once __DIR__ . '/../othernamespace/Foo.php';
+
+/**
+ * Class NamespaceWithUseClauseTest
+ *
+ * @package namespacetest
+ */
+class NamespaceWithUseClauseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMapArrayNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"data":[{"value":"1.2"}]}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\Unit', $res->data[0]);
+    }
+
+    public function testMapSimpleArrayNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"units":[{"value":"1.2"}]}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\Unit', $res->units[0]);
+    }
+
+    public function testMapSimpleStringArrayNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"messages":["message 1", "message 2"]}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertNotNull($res->messages);
+        $this->assertCount(2, $res->messages);
+    }
+
+    public function testMapChildClassNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"user":{"name": "John Smith"}}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\model\User', $res->user);
+    }
+
+    public function testMapChildClassConstructorNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"user":"John Smith"}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\model\User', $res->user);
+    }
+
+    public function testMapChildObjectArrayNamespace()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"data":[],"user":{"name": "John Smith"}}';
+        /* @var \namespacetest\UnitDataWithUseClause $res */
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\\ArrayObject', $res->data);
+        $this->assertInstanceOf('\namespacetest\model\User', $res->user);
+    }
+
+    /**
+     * @expectedException JsonMapper_Exception
+     * @expectedExceptionMessage Empty type at property "namespacetest\UnitDataWithUseClause::$empty"
+     */
+    public function testMapEmpty()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"empty":{}}';
+        /* @var \namespacetest\UnitDataWithUseClause $res */
+        $mapper->map(json_decode($json), new UnitDataWithUseClause());
+    }
+
+    public function testMapCustomArrayObjectWithChildType()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"users":[{"user":"John Smith"}]}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\model\UserList', $res->users);
+        $this->assertInstanceOf('\namespacetest\model\User', $res->users[0]);
+    }
+
+    public function testMapCustomArrayObject()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"aodata":["foo"]}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf('\namespacetest\model\MyArrayObject', $res->aodata);
+        $this->assertInternalType('string', $res->aodata[0]);
+        $this->assertEquals('foo', $res->aodata[0]);
+    }
+
+    /**
+     * Test a setter method with a namespaced type hint that
+     * is within another namespace than the object itself.
+     */
+    public function testSetterNamespacedTypeHint()
+    {
+        $mapper = new \JsonMapper();
+        $json = '{"namespacedTypeHint":"Foo"}';
+        $res = $mapper->map(json_decode($json), new UnitDataWithUseClause());
+        $this->assertInstanceOf('\namespacetest\UnitDataWithUseClause', $res);
+        $this->assertInstanceOf(
+            '\othernamespace\Foo', $res->internalData['namespacedTypeHint']
+        );
+        $this->assertEquals(
+            'Foo', $res->internalData['namespacedTypeHint']->name
+        );
+    }
+}
+?>

--- a/tests/namespacetest/UnitDataWithUseClause.php
+++ b/tests/namespacetest/UnitDataWithUseClause.php
@@ -1,0 +1,62 @@
+<?php
+namespace namespacetest;
+
+use namespacetest\model;
+use namespacetest\model\User;
+use namespacetest\model\UserList;
+use othernamespace\Foo;
+
+/**
+ * Class UnitDataWithUseClause
+ *
+ * @package namespacetest
+ */
+class UnitDataWithUseClause
+{
+    /**
+     * @var \ArrayObject[Unit]
+     */
+    public $data;
+
+    /**
+     * @var Unit[]
+     */
+    public $units;
+
+    /**
+     * @var string[]
+     */
+    public $messages;
+
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * @var
+     */
+    public $empty;
+
+    /**
+     * @var UserList[model\User]
+     */
+    public $users;
+
+    /**
+     * @var model\MyArrayObject
+     */
+    public $aodata;
+
+    public $internalData = array();
+
+
+    /**
+     * @param Foo $foo
+     */
+    public function setNamespacedTypeHint(Foo $foo)
+    {
+        $this->internalData['namespacedTypeHint'] = $foo;
+    }
+}
+?>


### PR DESCRIPTION
We are using your class on one of our projects, but it lacks support for use clauses. If one class has a property which type is a class from another namespace and that class name is simplified using the "use" clause, then jsonmapper will add the current namespace for it, ignoring the "use" information. Here is a code snip that would break:

File 1:
```
<?php
namespace Foo;
class Bar {};

```

File2:
```
<?php
namespace B;

use Foo;

class Z
{
   /** @var Bar */
   public $oX;
}
```
In this case, jsonmapper should map $oX as a Foo\Bar class, but instead, it will think it is a B\Bar.

To fix this, I have changed jsonmapper to find the use clauses on the class file, and use them to find the correct name for the attributes. For this to work, code must be PSR-1 compliant (one single namespace per file).
I did my best to follow your code standards, but used some prefixes on the variables (arr, str) to make the code easier to read, ok?
Hope it helps! :D 