### PR TITLE
Support of Psr-5 types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .buildpath
 .project
 .settings
+.idea

--- a/README.rst
+++ b/README.rst
@@ -404,6 +404,22 @@ If you do not want this, set ``$bStrictObjectTypeChecking`` to ``true``:
 
 An exception is then thrown in such cases.
 
+Lossy data conversion for simple types
+--------------------------------------
+
+Converting from a type to an other may result to loose some data. For example,
+you may don't want to convert `12.3` to an array or to a boolean,
+
+I you want to check a lossy data conversion, set ``$bStrictSimpleTypeConversionChecking``
+to ``true`` (an exception will then thrown) or set ``$bSimpleTypeLossyDataConversionChecking``
+to ``true`` (a message will be logged):
+
+.. code:: php
+
+    $jm = new JsonMapper();
+    $jm->bStrictSimpleTypeConversionChecking = true;
+    $jm->map(...);
+
 
 Passing arrays to ``map()``
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -230,8 +230,10 @@ It supports all type names specified in the PSR-5 specification (types for PHPDo
 
 - ArrayObjects of simple types and class names:
 
-  - ``ContactList[Contact]``
-  - ``NumberList[int]``
+  - ``ContactList<Contact>``
+  - ``NumberList<int>``
+  - ``ContactListWithStringsAsKeys<string,Contact>``
+  - Note that the syntax ``NumberList[int]`` is not supported anymore
 - Nullable types:
 
   - ``int|null`` - will be ``null`` if the value in JSON is

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,8 @@ gives you, but for JSON.
 It does not rely on any schema, only your PHP class definitions.
 
 Type detection works by parsing ``@var`` docblock annotations of
-class properties, as well as type hints in setter methods.
+class properties, as well as type hints in setter methods. It supports
+types annotations supported by the PSR-5 specification.
 
 You do not have to modify your model classes by adding JSON specific code;
 it works automatically by parsing already-existing docblocks.
@@ -199,6 +200,8 @@ a property:
 Supported type names
 --------------------
 
+It supports all type names specified in the PSR-5 specification (types for PHPDoc).
+
 - Simple types
 
   - ``string``
@@ -210,6 +213,9 @@ Supported type names
 - Class names, with and without namespaces
 
   - ``Contact`` - exception will be thrown if the JSON value is ``null``
+- List of possible types
+  - ``double|string|array``
+
 - Arrays of simple types and class names:
 
   - ``int[]``
@@ -218,6 +224,10 @@ Supported type names
 
   - ``int[][]``
   - ``TreeDeePixel[][][]``
+- Arrays with multiple type of items:
+
+   - ``(TreeDeePixel|Contact)[]``
+
 - ArrayObjects of simple types and class names:
 
   - ``ContactList[Contact]``
@@ -419,26 +429,6 @@ to ``true`` (a message will be logged):
     $jm = new JsonMapper();
     $jm->bStrictSimpleTypeConversionChecking = true;
     $jm->map(...);
-
-
-Passing arrays to ``map()``
----------------------------
-You may wish to pass array data into ``map()`` that you got by calling
-
-.. code:: php
-
-    json_decode($jsonString, true)
-
-By default, JsonMapper will throw an exception because ``map()`` requires
-an object as first parameter.
-You can circumvent that by setting ``$bEnforceMapType`` to ``false``:
-
-.. code:: php
-
-    $jm = new JsonMapper();
-    $jm->bEnforceMapType = false;
-    $jm->map(...);
-
 
 ============
 Installation

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "issues": "https://github.com/cweiske/jsonmapper/issues"
     },
     "require":{
-      "php": ">=5.6"
+      "php": ">=5.6",
+      "phpdocumentor/type-resolver": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require":{
       "php": ">=5.6",
-      "phpdocumentor/type-resolver": "dev-master"
+      "phpdocumentor/type-resolver": "1.0.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -409,6 +409,14 @@ class JsonMapper
 
         if ($type instanceof Object_) {
             $className = (string)$type->getFqsen();
+            if ($className == '') {
+                if (!is_object($jvalue)) {
+                    throw new JsonMapper_BadTypeException(
+                        "$jsonPath is not an object", $jsonPath
+                    );
+                }
+                return $jvalue;
+            }
             if ($className == '\\ArrayObject'
                 || is_subclass_of($className, '\\ArrayObject')
             ) {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -254,7 +254,7 @@ class JsonMapper
             }
             $propPath = $jsonPath . '->' . $key;
             try {
-                $value = $this->getPHPValue($jvalue, $propPath, $type, $classNamespace);
+                $value = $this->getPHPValue($jvalue, $propPath, $type);
             }
             catch(JsonMapper_BadTypeException $exception) {
                 throw new JsonMapper_BadPropertyTypeException(
@@ -287,12 +287,11 @@ class JsonMapper
      * @param mixed $jvalue
      * @param string $jsonPath
      * @param Type $type
-     * @param string $classNamespace
      *
      * @return mixed
      * @throws JsonMapper_Exception
      */
-    protected function getPHPValue($jvalue, $jsonPath, Type $type = null, $classNamespace = '')
+    protected function getPHPValue($jvalue, $jsonPath, Type $type = null)
     {
         if ($type === null) {
             /*throw new JsonMapper_Exception(
@@ -345,27 +344,25 @@ class JsonMapper
         }
         
         if ($type instanceof Array_) {
-            return $this->_mapArray($jvalue, $jsonPath, $classNamespace, $type->getValueType());
+            return $this->_mapArray($jvalue, $jsonPath, $type->getValueType());
         }
 
         if ($type instanceof Iterable_) {
-            return $this->_mapArray($jvalue, $jsonPath, $classNamespace);
+            return $this->_mapArray($jvalue, $jsonPath);
         }
 
         if ($type instanceof Compound) {
-            return $this->mapCompound($jvalue, $type, $jsonPath, $classNamespace);
+            return $this->mapCompound($jvalue, $type, $jsonPath);
         }
 
         if ($type instanceof Object_) {
             $className = (string)$type->getFqsen();
-            //$expectedClass = (string)$type->getFqsen();
-            //$className = $this->getFullNamespace($expectedClass, $classNamespace);
             if ($className == '\\ArrayObject'
                 || is_subclass_of($className, '\\ArrayObject')
             ) {
 
                 $array = $this->createInstance($className);
-                return $this->_mapArray($jvalue, $jsonPath, $classNamespace, null, $array);
+                return $this->_mapArray($jvalue, $jsonPath, null, $array);
             }
 
             if ($this->isFlatType(gettype($jvalue))) {
@@ -388,26 +385,6 @@ class JsonMapper
         throw new JsonMapper_Exception(
             'Expected type "'.$type.'" is not supported by JSON mapper'
         );
-    }
-
-    /**
-     * Convert a type name to a fully namespaced type name.
-     *
-     * @param string $type  Type name (simple type or class name)
-     * @param string $strNs Base namespace that gets prepended to the type name
-     *
-     * @return string Fully-qualified type name with namespace
-     */
-    protected function getFullNamespace($type, $strNs)
-    {
-        if ($type !== '' && $type{0} != '\\') {
-            echo "#####!!!!!!!!!##### \ncreate a full qualified namespace from $type -> $strNs\n";
-            //create a full qualified namespace
-            if ($strNs != '') {
-                $type = '\\' . $strNs . '\\' . $type;
-            }
-        }
-        return $type;
     }
 
     /**
@@ -474,15 +451,13 @@ class JsonMapper
      *
      * @param array  $json  JSON array structure from json_decode()
      * @param string $jsonPath
-     * @param string $classNamespace
      * @param Type   $itemType  the expected type for array values
      * @param object $array ArrayObject that gets filled with
      *                      data from $json
      *
      * @return mixed Mapped $array is returned
      */
-    public function _mapArray($json, $jsonPath, $classNamespace = '',
-                             $itemType = null, \Traversable $array = null)
+    public function _mapArray($json, $jsonPath, $itemType = null, \Traversable $array = null)
     {
         if (!is_array($json) && !is_object($json)) {
             throw new JsonMapper_BadTypeException(
@@ -513,7 +488,7 @@ class JsonMapper
             $key = $this->getSafeName($key);
             $jsonValuePath = $jsonPath.'['.$key.']';
             try {
-                $value = $this->getPHPValue($jvalue, $jsonValuePath, $itemType, $classNamespace);
+                $value = $this->getPHPValue($jvalue, $jsonValuePath, $itemType);
             }
             catch(JsonMapper_BadTypeException $exception) {
                 if ($key > 0) {
@@ -538,14 +513,13 @@ class JsonMapper
      * @param mixed $jvalue
      * @param Compound $type
      * @param string $jsonPath
-     * @param string $classNamespace
      * @return mixed the php value
      */
-    protected function mapCompound($jvalue, Compound $list, $jsonPath, $classNamespace)
+    protected function mapCompound($jvalue, Compound $list, $jsonPath)
     {
         foreach($list->getIterator() as $type) {
             try {
-                return $this->getPHPValue($jvalue, $jsonPath, $type, $classNamespace);
+                return $this->getPHPValue($jvalue, $jsonPath, $type);
             }
             catch(JsonMapper_UnknownPropertyException $e) {
                 // not the good class

--- a/src/JsonMapper/BadItemTypeException.php
+++ b/src/JsonMapper/BadItemTypeException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+
+/**
+ * exception for bad type of an array item
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+class JsonMapper_BadItemTypeException extends JsonMapper_BadTypeException
+{
+}
+

--- a/src/JsonMapper/BadItemTypeException.php
+++ b/src/JsonMapper/BadItemTypeException.php
@@ -1,6 +1,10 @@
 <?php
 /**
+ * Part of JsonMapper
  *
+ * PHP version 5
+ *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -8,8 +12,9 @@
  */
 
 /**
- * exception for bad type of an array item
+ * Exception for bad type of an array item
  *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -18,4 +23,3 @@
 class JsonMapper_BadItemTypeException extends JsonMapper_BadTypeException
 {
 }
-

--- a/src/JsonMapper/BadPropertyTypeException.php
+++ b/src/JsonMapper/BadPropertyTypeException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+
+/**
+ * exception for bad type of an object property
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+class JsonMapper_BadPropertyTypeException extends JsonMapper_BadTypeException
+{
+}
+

--- a/src/JsonMapper/BadPropertyTypeException.php
+++ b/src/JsonMapper/BadPropertyTypeException.php
@@ -1,6 +1,10 @@
 <?php
 /**
+ * Part of JsonMapper
  *
+ * PHP version 5
+ *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -8,8 +12,9 @@
  */
 
 /**
- * exception for bad type of an object property
+ * Exception for bad type of an object property
  *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -18,4 +23,3 @@
 class JsonMapper_BadPropertyTypeException extends JsonMapper_BadTypeException
 {
 }
-

--- a/src/JsonMapper/BadTypeException.php
+++ b/src/JsonMapper/BadTypeException.php
@@ -34,10 +34,10 @@ class JsonMapper_BadTypeException extends JsonMapper_Exception
      * @param string         $jsonPath the path in JSON to the item that causes
      *                                 the error
      * @param int            $code     the error code
-     * @param Throwable|null $previous the parent exception
+     * @param Exception|null $previous the parent exception
      */
     public function __construct ($message = "", $jsonPath = '', $code = 0,
-        Throwable $previous = null
+        Exception $previous = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->jsonPath = $jsonPath;

--- a/src/JsonMapper/BadTypeException.php
+++ b/src/JsonMapper/BadTypeException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+
+/**
+ * general exception for bad types
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+class JsonMapper_BadTypeException extends JsonMapper_Exception
+{
+    protected $jsonPath = "";
+
+    public function __construct ($message = "", $jsonPath = '', $code = 0, Throwable $previous = NULL) {
+        parent::__construct($message, $code, $previous);
+        $this->jsonPath = $jsonPath;
+    }
+
+    public function getJsonPath() {
+        return $this->jsonPath;
+    }
+}
+

--- a/src/JsonMapper/BadTypeException.php
+++ b/src/JsonMapper/BadTypeException.php
@@ -1,6 +1,10 @@
 <?php
 /**
+ * Part of JsonMapper
  *
+ * PHP version 5
+ *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -8,8 +12,9 @@
  */
 
 /**
- * general exception for bad types
+ * General exception for bad types
  *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -17,15 +22,34 @@
  */
 class JsonMapper_BadTypeException extends JsonMapper_Exception
 {
+    /**
+     * @var string the path in JSON to the item that causes the error
+     */
     protected $jsonPath = "";
 
-    public function __construct ($message = "", $jsonPath = '', $code = 0, Throwable $previous = NULL) {
+    /**
+     * JsonMapper_BadTypeException constructor.
+     *
+     * @param string         $message  the error message
+     * @param string         $jsonPath the path in JSON to the item that causes
+     *                                 the error
+     * @param int            $code     the error code
+     * @param Throwable|null $previous the parent exception
+     */
+    public function __construct ($message = "", $jsonPath = '', $code = 0,
+        Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
         $this->jsonPath = $jsonPath;
     }
 
-    public function getJsonPath() {
+    /**
+     * gets the json path of the error
+     *
+     * @return string
+     */
+    public function getJsonPath()
+    {
         return $this->jsonPath;
     }
 }
-

--- a/src/JsonMapper/UnknownPropertyException.php
+++ b/src/JsonMapper/UnknownPropertyException.php
@@ -1,6 +1,10 @@
 <?php
 /**
+ * Part of JsonMapper
  *
+ * PHP version 5
+ *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -8,8 +12,9 @@
  */
 
 /**
- * general exception for bad types
+ * General exception for bad types
  *
+ * @category Netresearch
  * @package  JsonMapper
  * @author   Laurent Jouanneau <dev@ljouanneau.com>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
@@ -17,15 +22,34 @@
  */
 class JsonMapper_UnknownPropertyException extends JsonMapper_Exception
 {
+    /**
+     * @var string the path in JSON to the item that causes the error
+     */
     protected $jsonPath = "";
 
-    public function __construct ($message = "", $jsonPath = '', Throwable $previous = NULL, $code = 0) {
+    /**
+     * JsonMapper_UnknownPropertyException constructor.
+     *
+     * @param string         $message  the error message
+     * @param string         $jsonPath the path in JSON to the item that causes
+     *                                 the error
+     * @param int            $code     the error code
+     * @param Throwable|null $previous the parent exception
+     */
+    public function __construct ($message = "", $jsonPath = '', $code = 0,
+        Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
         $this->jsonPath = $jsonPath;
     }
 
-    public function getJsonPath() {
+    /**
+     * gets the json path of the error
+     *
+     * @return string
+     */
+    public function getJsonPath()
+    {
         return $this->jsonPath;
     }
 }
-

--- a/src/JsonMapper/UnknownPropertyException.php
+++ b/src/JsonMapper/UnknownPropertyException.php
@@ -34,10 +34,10 @@ class JsonMapper_UnknownPropertyException extends JsonMapper_Exception
      * @param string         $jsonPath the path in JSON to the item that causes
      *                                 the error
      * @param int            $code     the error code
-     * @param Throwable|null $previous the parent exception
+     * @param Exception|null $previous the parent exception
      */
     public function __construct ($message = "", $jsonPath = '', $code = 0,
-        Throwable $previous = null
+        Exception $previous = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->jsonPath = $jsonPath;

--- a/src/JsonMapper/UnknownPropertyException.php
+++ b/src/JsonMapper/UnknownPropertyException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+
+/**
+ * general exception for bad types
+ *
+ * @package  JsonMapper
+ * @author   Laurent Jouanneau <dev@ljouanneau.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+class JsonMapper_UnknownPropertyException extends JsonMapper_Exception
+{
+    protected $jsonPath = "";
+
+    public function __construct ($message = "", $jsonPath = '', Throwable $previous = NULL, $code = 0) {
+        parent::__construct($message, $code, $previous);
+        $this->jsonPath = $jsonPath;
+    }
+
+    public function getJsonPath() {
+        return $this->jsonPath;
+    }
+}
+

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -360,6 +360,26 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($sn->nMatrix[2]));
     }
 
+
+    /**
+     * Test for an array for an Iterable property
+     */
+    public function testIterable()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"iterable":[1,2,3,4]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertInstanceof('ArrayObject', $sn->iterable);
+        $this->assertEquals(4, count($sn->iterable));
+        $this->assertEquals(1, $sn->iterable[0]);
+        $this->assertEquals(2, $sn->iterable[1]);
+        $this->assertEquals(3, $sn->iterable[2]);
+        $this->assertEquals(4, $sn->iterable[3]);
+    }
+
+
     /**
      * Test for an array of arrays of arrays of objects
      * "@var JsonMapper_Simple[][][]"
@@ -384,5 +404,77 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
             'JsonMapperTest_Simple', $sn->pMultiverse[0][0][0]
         );
     }
+
+    /**
+     * Test for mapping data to an array using mapArray
+     */
+    public function testMapArrayWithClass()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->mapArray(
+            json_decode('[{"pStr":"hello"}, {"pStr":"World"}]'),
+            array(),
+            'JsonMapperTest_PlainObject'
+        );
+
+        $this->assertInternalType('array', $sn);
+        $this->assertEquals(2, count($sn));
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn[0]);
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn[1]);
+        $this->assertEquals('hello', $sn[0]->pStr);
+        $this->assertEquals('World', $sn[1]->pStr);
+    }
+
+    /**
+     * Test for mapping data to an array using mapArray containing any data
+     */
+    public function testMapArrayWithAnyData()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->mapArray(
+            json_decode('[{"pStr":"hello"}, 548, {"pStr":"World"}]'),
+            array()
+        );
+
+        $this->assertInternalType('array', $sn);
+        $this->assertEquals(3, count($sn));
+        $this->assertEquals(548, $sn[1]);
+        $this->assertInstanceOf('StdClass', $sn[0]);
+        $this->assertInstanceOf('StdClass', $sn[2]);
+        $this->assertEquals('hello', $sn[0]->pStr);
+        $this->assertEquals('World', $sn[2]->pStr);
+    }
+
+    /**
+     * Test for mapping data to an ArrayObject using mapArray
+     */
+    public function testMapArrayObjectWithClass()
+    {
+        $ar = new ArrayObject();
+        $jm = new JsonMapper();
+        $sn = $jm->mapArray(
+            json_decode('[{"pStr":"hello"}, {"pStr":"World"}]'),
+            $ar,
+            'JsonMapperTest_PlainObject'
+        );
+
+        $this->assertInstanceOf('ArrayObject', $sn);
+        $this->assertEquals(2, count($sn));
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn[0]);
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn[1]);
+        $this->assertEquals('hello', $sn[0]->pStr);
+        $this->assertEquals('World', $sn[1]->pStr);
+    }
+
+    /**
+     * @expectedException        JsonMapper_Exception
+     * @expectedExceptionMessage Error for JSON property "{}->unsupportedCollection" for class JsonMapperTest_Array: JSON mapper doesn't support collection key types other than string and integers
+     */
+    public function testUnsupportedCollection()
+    {
+        $jm = new JsonMapper();
+        $json   = '{"unsupportedCollection" : ["hello"]}';
+        $jm->map(json_decode($json), new JsonMapperTest_Array());
+    }
 }
-?>
+

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -51,21 +51,45 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
-            json_decode('{"typedSimpleArray":["2014-01-02",null,"2014-05-07"]}'),
+            json_decode('{"typedSimpleArray":["2014-01-02","2014-05-07"]}'),
             new JsonMapperTest_Array()
         );
         $this->assertInternalType('array', $sn->typedSimpleArray);
-        $this->assertEquals(3, count($sn->typedSimpleArray));
+        $this->assertEquals(2, count($sn->typedSimpleArray));
         $this->assertInstanceOf('DateTime', $sn->typedSimpleArray[0]);
-        $this->assertNull($sn->typedSimpleArray[1]);
-        $this->assertInstanceOf('DateTime', $sn->typedSimpleArray[2]);
+        $this->assertInstanceOf('DateTime', $sn->typedSimpleArray[1]);
         $this->assertEquals(
             '2014-01-02', $sn->typedSimpleArray[0]->format('Y-m-d')
         );
         $this->assertEquals(
-            '2014-05-07', $sn->typedSimpleArray[2]->format('Y-m-d')
+            '2014-05-07', $sn->typedSimpleArray[1]->format('Y-m-d')
         );
     }
+
+    /**
+     * Test for an array of classes "@var (ClassName|null)[]" with
+     * flat/simple json values (string)
+     */
+    public function testMapTypedSimpleArrayWithNullable()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"typedSimpleArrayWithNullable":["2014-01-02",null,"2014-05-07"]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertInternalType('array', $sn->typedSimpleArrayWithNullable);
+        $this->assertEquals(3, count($sn->typedSimpleArrayWithNullable));
+        $this->assertInstanceOf('DateTime', $sn->typedSimpleArrayWithNullable[0]);
+        $this->assertNull($sn->typedSimpleArray[1]);
+        $this->assertInstanceOf('DateTime', $sn->typedSimpleArrayWithNullable[2]);
+        $this->assertEquals(
+            '2014-01-02', $sn->typedSimpleArrayWithNullable[0]->format('Y-m-d')
+        );
+        $this->assertEquals(
+            '2014-05-07', $sn->typedSimpleArrayWithNullable[2]->format('Y-m-d')
+        );
+    }
+
 
     /**
      * Test for an array that is nullable - "@var string[]|null"
@@ -80,12 +104,14 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($sn->nullableSimpleArray);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testMapArrayJsonNoTypeEnforcement()
     {
         $jm = new JsonMapper();
         $jm->bEnforceMapType = false;
         $sn = $jm->map(array(), new JsonMapperTest_Simple());
-        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
     }
 
     /**
@@ -140,23 +166,6 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test for an array of strings - "@var array[string]"
-     */
-    public function testStrArrayV2()
-    {
-        $jm = new JsonMapper();
-        $sn = $jm->map(
-            json_decode('{"strArrayV2":["str",false,2.048]}'),
-            new JsonMapperTest_Array()
-        );
-        $this->assertInternalType('array', $sn->strArrayV2);
-        $this->assertEquals(3, count($sn->strArrayV2));
-        $this->assertInternalType('string', $sn->strArrayV2[0]);
-        $this->assertInternalType('string', $sn->strArrayV2[1]);
-        $this->assertInternalType('string', $sn->strArrayV2[2]);
-    }
-
-    /**
      * Test for "@var ArrayObject"
      */
     public function testMapArrayObject()
@@ -177,7 +186,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     /**
      * Test for "@var ArrayObject[Classname]"
      */
-    public function testMapTypedArrayObject()
+    /*public function testMapTypedArrayObject()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
@@ -192,12 +201,12 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('JsonMapperTest_Simple', $sn->pTypedArrayObject[1]);
         $this->assertEquals('stringvalue', $sn->pTypedArrayObject[0]->str);
         $this->assertEquals('1.2', $sn->pTypedArrayObject[1]->fl);
-    }
+    }*/
 
     /**
-     * Test for "@var ArrayObject[int]"
+     * Test for "@var \ArrayObject<int>"
      */
-    public function testMapSimpleArrayObject()
+    /*public function testMapSimpleArrayObject()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
@@ -212,11 +221,11 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('int', $sn->pSimpleArrayObject['zwei']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['eins']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['zwei']);
-    }
+    }*/
 
     /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "flArray" must be an array, integer given
+     * @expectedException JsonMapper_BadTypeException
+     * @expectedExceptionMessage JSON property "{}->flArray" has not the expected type float[] in object of type JsonMapperTest_Array: JSON value at {}->flArray must be an array, integer given
      */
     public function testInvalidArray()
     {
@@ -228,8 +237,8 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pArrayObject" must be an array, double given
+     * @expectedException JsonMapper_BadTypeException
+     * @expectedExceptionMessage JSON property "{}->pArrayObject" has not the expected type \ArrayObject in object of type JsonMapperTest_Array: JSON value at {}->pArrayObject must be an array, double given
      */
     public function testInvalidArrayObject()
     {
@@ -256,8 +265,8 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     /**
      * An ArrayObject which may not be null but is.
      *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pArrayObject" in class "JsonMapperTest_Array" must not be NULL
+     * @expectedException JsonMapper_BadTypeException
+     * @expectedExceptionMessage JSON property "{}->pArrayObject" has not the expected type \ArrayObject in object of type JsonMapperTest_Array: JSON value at {}->pArrayObject must not be NULL
      */
     public function testArrayObjectInvalidNull()
     {
@@ -289,7 +298,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
      *
      * @runInSeparateProcess
      */
-    public function testMapTypedArrayObjectDoesNotExist()
+    /*public function testMapTypedArrayObjectDoesNotExist()
     {
         $this->assertTrue(
             spl_autoload_register(
@@ -308,7 +317,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             'ThisClassDoesNotExist', $sn->pTypedArrayObjectNoClass[0]
         );
-    }
+    }*/
 
     public function mapTypedArrayObjectDoesNotExistAutoloader($class)
     {

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -184,9 +184,9 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test for "@var ArrayObject[Classname]"
+     * Test for "@var \ArrayObject<Classname>"
      */
-    /*public function testMapTypedArrayObject()
+    public function testMapTypedArrayObject()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
@@ -201,12 +201,12 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('JsonMapperTest_Simple', $sn->pTypedArrayObject[1]);
         $this->assertEquals('stringvalue', $sn->pTypedArrayObject[0]->str);
         $this->assertEquals('1.2', $sn->pTypedArrayObject[1]->fl);
-    }*/
+    }
 
     /**
      * Test for "@var \ArrayObject<int>"
      */
-    /*public function testMapSimpleArrayObject()
+    public function testMapSimpleArrayObject()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
@@ -221,7 +221,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('int', $sn->pSimpleArrayObject['zwei']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['eins']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['zwei']);
-    }*/
+    }
 
     /**
      * @expectedException JsonMapper_BadTypeException
@@ -298,7 +298,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
      *
      * @runInSeparateProcess
      */
-    /*public function testMapTypedArrayObjectDoesNotExist()
+    public function testMapTypedArrayObjectDoesNotExist()
     {
         $this->assertTrue(
             spl_autoload_register(
@@ -317,7 +317,7 @@ class ArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             'ThisClassDoesNotExist', $sn->pTypedArrayObjectNoClass[0]
         );
-    }*/
+    }
 
     public function mapTypedArrayObjectDoesNotExistAutoloader($class)
     {

--- a/tests/JsonMapperTest/Array.php
+++ b/tests/JsonMapperTest/Array.php
@@ -33,11 +33,6 @@ class JsonMapperTest_Array
     public $strArray;
 
     /**
-     * @var array[string]
-     */
-    public $strArrayV2;
-
-    /**
      * @var JsonMapperTest_Simple[]
      * @see http://phpdoc.org/docs/latest/references/phpdoc/types.html#arrays
      */
@@ -47,6 +42,11 @@ class JsonMapperTest_Array
      * @var DateTime[]
      */
     public $typedSimpleArray;
+
+    /**
+     * @var (DateTime|null)[]
+     */
+    public $typedSimpleArrayWithNullable;
 
     /**
      * @var string[]|null
@@ -68,12 +68,12 @@ class JsonMapperTest_Array
 
     /**
      * This generates an array object with JsonMapperTest_Simple instances
-     * @var ArrayObject[JsonMapperTest_Simple]
+     * @var ArrayObject<JsonMapperTest_Simple>
      */
     public $pTypedArrayObject;
 
     /**
-     * @var ArrayObject[int]
+     * @var ArrayObject<int>
      */
     public $pSimpleArrayObject;
 

--- a/tests/JsonMapperTest/Array.php
+++ b/tests/JsonMapperTest/Array.php
@@ -88,5 +88,14 @@ class JsonMapperTest_Array
      * @var JsonMapperTest_Simple[][][]
      */
     public $pMultiverse;
+
+    /**
+     * @var ArrayObject<JsonMapperTest_Simple,DateTime>
+     */
+    public $unsupportedCollection;
+
+    /**
+     * @var Iterable
+     */
+    public $iterable;
 }
-?>

--- a/tests/JsonMapperTest/Broken.php
+++ b/tests/JsonMapperTest/Broken.php
@@ -23,7 +23,7 @@
 class JsonMapperTest_Broken
 {
     /**
-     * @var ArrayObject[ThisClassDoesNotExist]
+     * @var \ArrayObject<ThisClassDoesNotExist>
      */
     public $pTypedArrayObjectNoClass;
 

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -116,6 +116,11 @@ class JsonMapperTest_Simple
      */
     public $valueObject;
 
+    /**
+     * @var object
+     */
+    public $anyObject;
+
     public function setSimpleSetterOnlyTypeHint(JsonMapperTest_Simple $s)
     {
         $this->internalData['typehint'] = $s;

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -101,6 +101,16 @@ class JsonMapperTest_Simple
     public $setterPreferredOverProperty;
 
     /**
+     * @var callable
+     */
+    public $callableProperty;
+
+    /**
+     * @var string|int|JsonMapperTest_PlainObject|JsonMapperTest_Object
+     */
+    public $compound;
+
+    /**
      * Value object which needs to be set as an instance (without mapping)
      * @var JsonMapperTest_ValueObject
      */

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -193,5 +193,80 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
             $sn->pPlainObject->format('c')
         );
     }
+
+    public function testClassMapWithNamespace()
+    {
+        $jm = new JsonMapper();
+        $jm->classMap['\\JsonMapperTest_PlainObject'] = 'DateTime';
+        $sn = $jm->map(
+            json_decode('{"pPlainObject":"2016-04-14T23:15:42+02:00"}'),
+            new JsonMapperTest_Object()
+        );
+
+        $this->assertInternalType('object', $sn->pPlainObject);
+        $this->assertInstanceOf('DateTime', $sn->pPlainObject);
+        $this->assertEquals(
+            '2016-04-14T23:15:42+02:00',
+            $sn->pPlainObject->format('c')
+        );
+    }
+
+    public function testCompound1() {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"compound":"hello"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
+        $this->assertEquals("hello", $sn->compound);
+    }
+
+    public function testCompound2() {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"compound":123}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
+        $this->assertEquals(123, $sn->compound);
+    }
+
+    public function testCompound3() {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"compound":{"pStr":"hello"}}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn->compound);
+        $this->assertEquals("hello", $sn->compound->pStr);
+    }
+
+    public function testCompound4() {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"compound":{"pValueObject":{"publicValue":"hello"}}}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
+        $this->assertInstanceOf('JsonMapperTest_Object', $sn->compound);
+        $this->assertInstanceOf('JsonMapperTest_ValueObject', $sn->compound->pValueObject);
+        $this->assertEquals("hello", $sn->compound->pValueObject->publicValue);
+    }
+
+    /**
+     * Test for compound with a property with the good name but a bad type
+     *
+     * @expectedException JsonMapper_Exception
+     * @expectedExceptionMessage Error for JSON property "{}->compound" for class JsonMapperTest_Simple: Error for JSON property "{}->compound->pPlainObject" for class JsonMapperTest_Object: JSON property "{}->compound->pPlainObject->foo" does not exist in object of type JsonMapperTest_PlainObject
+     */
+    public function testCompoundGoodPropertyNameBadType() {
+        $jm = new JsonMapper();
+        $jm->map(
+            json_decode('{"compound":{"pPlainObject":{ "foo":54}}}'),
+            new JsonMapperTest_Simple()
+        );
+    }
+
 }
 ?>

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -177,6 +177,21 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('null', $sn->pValueObjectNullable);
     }
 
+    /**
+     * Test for "@var object"
+     */
+    public function testMapObjectPropertyWithAnyObject()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"anyObject":{"str":"stringvalue"}}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('object', $sn->anyObject);
+        $this->assertInstanceOf('stdClass', $sn->anyObject);
+        $this->assertEquals('stringvalue', $sn->anyObject->str);
+    }
+
     public function testClassMap()
     {
         $jm = new JsonMapper();

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -110,7 +110,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pValueObject" must be an object, string given
+     * @expectedExceptionMessage JSON property "{}->pValueObject" has not the expected type \JsonMapperTest_ValueObject in object of type JsonMapperTest_Object: JSON value at {}->pValueObject must be an object, string given
      */
     public function testStrictTypeCheckingObjectError()
     {
@@ -165,7 +165,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
      * Test for "@var object" with null value
      *
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pValueObject" in class "JsonMapperTest_Object" must not be NULL
+     * @expectedExceptionMessage JSON property "{}->pValueObject" has not the expected type \JsonMapperTest_ValueObject in object of type JsonMapperTest_Object: JSON value at {}->pValueObject must not be NULL
      */
     public function testObjectInvalidNull()
     {

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -327,5 +327,37 @@ class OtherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('second level', $sn->simple->str);
         $this->assertEquals('database', $sn->simple->db);
     }
+
+
+    public function testLossyDataConversionSimple() {
+        $jm = new JsonMapper();
+        $jm->bSimpleTypeLossyDataConversionChecking = true;
+        $jm->bStrictSimpleTypeConversionChecking = true;
+
+        $sn = $jm->map(
+            json_decode('{"pbool":false,"pboolean":true,"pint":456,"pinteger":456,"pnullable":null,'
+                    .'"fl":63.21,"mixed":"h","str":"string","simple":{"str":"world"}}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn);
+        $this->assertFalse($sn->pbool);
+        $this->assertTrue($sn->pboolean);
+        $this->assertEquals(456, $sn->pint);
+        $this->assertEquals('string', $sn->str);
+        $this->assertEquals('world', $sn->simple->str);
+    }
+
+    /**
+     * @expectedException        JsonMapper_Exception
+     * @expectedExceptionMessage JSON property "{}->callableProperty" has not the expected type callable in object of type JsonMapperTest_Simple: JSON value at {}->callableProperty should not be given, as target property must contain a resource or a callable
+     */
+    public function testCallableProperty()
+    {
+        $jm = new JsonMapper();
+        $json   = '{"callableProperty" : "hello"}';
+        $jm->map(json_decode($json), new JsonMapperTest_Simple());
+    }
+
+
 }
 ?>

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -53,7 +53,7 @@ class OtherTest extends \PHPUnit_Framework_TestCase
      * Test for "@var "
      *
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage Empty type at property "JsonMapperTest_Simple::$empty"
+     * @expectedExceptionMessage Error during the parsing of the type for {}: Attempted to resolve "" but it appears to be empty
      */
     public function testMapEmpty()
     {
@@ -146,7 +146,7 @@ class OtherTest extends \PHPUnit_Framework_TestCase
                     'Property {property} has no public setter method in {class}',
                     array(
                         'class' => 'JsonMapperTest_Simple',
-                        'property' => 'protectedStrNoSetter'
+                        'property' => '{}->protectedStrNoSetter'
                     )
                 )
             ),
@@ -184,7 +184,7 @@ class OtherTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "undefinedProperty" does not exist in object of type JsonMapperTest_Broken
+     * @expectedExceptionMessage JSON property "{}->undefinedProperty" does not exist in object of type JsonMapperTest_Broken
      */
     public function testUndefinedPropertyException()
     {
@@ -229,7 +229,7 @@ class OtherTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "privateNoSetter" has no public setter method in object of type PrivateWithSetter
+     * @expectedExceptionMessage JSON property "{}->privateNoSetter" has no public setter method in object of type PrivateWithSetter
      */
     public function testPrivatePropertyWithNoSetter()
     {
@@ -258,7 +258,7 @@ class OtherTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter
+     * @expectedExceptionMessage JSON property "{}->privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter
      */
     public function testPrivatePropertyWithPrivateSetter()
     {

--- a/tests/PHP7_ObjectTest.php
+++ b/tests/PHP7_ObjectTest.php
@@ -51,7 +51,7 @@ class PHP7_1_ObjectTest extends \PHPUnit_Framework_TestCase
      * Test for non-nullable types like "@param object" with null value
      *
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "nonNullableObject" in class "JsonMapperTest_PHP7_Object" must not be NULL
+     * @expectedExceptionMessage JSON property "{}->nonNullableObject" has not the expected type \JsonMapperTest_PlainObject in object of type JsonMapperTest_PHP7_Object: JSON value at {}->nonNullableObject must not be NULL
      */
     public function testObjectSetterDocblockInvalidNull()
     {

--- a/tests/namespacetest/NamespaceTest.php
+++ b/tests/namespacetest/NamespaceTest.php
@@ -9,14 +9,14 @@ require_once __DIR__ . '/../othernamespace/Foo.php';
 
 class NamespaceTest extends \PHPUnit_Framework_TestCase
 {
-    /*public function testMapArrayNamespace()
+    public function testMapArrayNamespace()
     {
         $mapper = new \JsonMapper();
         $json = '{"data":[{"value":"1.2"}]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
         $this->assertInstanceOf('\namespacetest\Unit', $res->data[0]);
-    }*/
+    }
 
     public function testMapSimpleArrayNamespace()
     {
@@ -55,15 +55,15 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\namespacetest\model\User', $res->user);
     }
 
-    /*public function testMapChildObjectArrayNamespace()
+    public function testMapChildObjectArrayNamespace()
     {
         $mapper = new \JsonMapper();
         $json = '{"data":[],"user":{"name": "John Smith"}}';
         /* @var \namespacetest\UnitData $res */
-        /*$res = $mapper->map(json_decode($json), new UnitData());
+        $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\\ArrayObject', $res->data);
         $this->assertInstanceOf('\namespacetest\model\User', $res->user);
-    }*/
+    }
 
     /**
      * @expectedException JsonMapper_Exception
@@ -77,7 +77,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $res = $mapper->map(json_decode($json), new UnitData());
     }
 
-    /*public function testMapCustomArrayObjectWithChildType()
+    public function testMapCustomArrayObjectWithChildType()
     {
         $mapper = new \JsonMapper();
         $json = '{"users":[{"user":"John Smith"}]}';
@@ -85,7 +85,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
         $this->assertInstanceOf('\namespacetest\model\UserList', $res->users);
         $this->assertInstanceOf('\namespacetest\model\User', $res->users[0]);
-    }*/
+    }
 
     public function testMapCustomArrayObject()
     {

--- a/tests/namespacetest/NamespaceTest.php
+++ b/tests/namespacetest/NamespaceTest.php
@@ -9,14 +9,14 @@ require_once __DIR__ . '/../othernamespace/Foo.php';
 
 class NamespaceTest extends \PHPUnit_Framework_TestCase
 {
-    public function testMapArrayNamespace()
+    /*public function testMapArrayNamespace()
     {
         $mapper = new \JsonMapper();
         $json = '{"data":[{"value":"1.2"}]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
         $this->assertInstanceOf('\namespacetest\Unit', $res->data[0]);
-    }
+    }*/
 
     public function testMapSimpleArrayNamespace()
     {
@@ -55,19 +55,19 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\namespacetest\model\User', $res->user);
     }
 
-    public function testMapChildObjectArrayNamespace()
+    /*public function testMapChildObjectArrayNamespace()
     {
         $mapper = new \JsonMapper();
         $json = '{"data":[],"user":{"name": "John Smith"}}';
         /* @var \namespacetest\UnitData $res */
-        $res = $mapper->map(json_decode($json), new UnitData());
+        /*$res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\\ArrayObject', $res->data);
         $this->assertInstanceOf('\namespacetest\model\User', $res->user);
-    }
+    }*/
 
     /**
      * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage Empty type at property "namespacetest\UnitData::$empty"
+     * @expectedExceptionMessage Error during the parsing of the type for {}: Attempted to resolve "" but it appears to be empty
      */
     public function testMapEmpty()
     {
@@ -77,7 +77,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $res = $mapper->map(json_decode($json), new UnitData());
     }
 
-    public function testMapCustomArrayObjectWithChildType()
+    /*public function testMapCustomArrayObjectWithChildType()
     {
         $mapper = new \JsonMapper();
         $json = '{"users":[{"user":"John Smith"}]}';
@@ -85,7 +85,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
         $this->assertInstanceOf('\namespacetest\model\UserList', $res->users);
         $this->assertInstanceOf('\namespacetest\model\User', $res->users[0]);
-    }
+    }*/
 
     public function testMapCustomArrayObject()
     {

--- a/tests/namespacetest/UnitData.php
+++ b/tests/namespacetest/UnitData.php
@@ -29,7 +29,7 @@ class UnitData
     public $empty;
 
     /**
-     * @var model\UserList[model\User]
+     * @var model\UserList<model\User>
      */
     public $users;
 

--- a/tests/namespacetest/UnitData.php
+++ b/tests/namespacetest/UnitData.php
@@ -4,7 +4,7 @@ namespace namespacetest;
 class UnitData
 {
     /**
-     * @var \ArrayObject[Unit]
+     * @var \ArrayObject<Unit>
      */
     public $data;
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -7,6 +7,11 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          checkForUnintentionallyCoveredCode="true"
 >
+    <testsuites>
+        <testsuite name="unit">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist>
             <directory suffix=".php">../src/</directory>


### PR DESCRIPTION
These changes brings support of [PSR-5](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types) types.

The library [TypeResolver from PhpDocumentor](https://github.com/phpDocumentor/TypeResolver) is used to parse all `@param` and `@var` types, including array expressions like `(string|object)[]` (an array that can contain strings and objects) and collections like `ArrayObject<string,Contact>` (an ArrayObject that must contain Contact objects as values and strings as keys). 

As the syntax `ArrayObject[Contact]` for collections is not defined in the PSR-5 specification, it is not supported anymore by JsonMapper.

The use of TypeResolver brings also the support of `use` keyword in class files, as asked in pull request #82. To avoid performance issue when reading files to parse file classes, I will propose a patch (already written and tested) to add support of PSR-16 simple cache, so results from parsing of  `@param` and `@var` could be stored in a cache.