### PR TITLE
Fix potential type error

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -210,6 +210,12 @@ class JsonMapper
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;
             } else if ($this->isSimpleType($type)) {
+                if (is_object($jvalue) && $type==='string') {
+                    throw new JsonMapper_Exception(
+                        'JSON property "' . $key . '" in class "'
+                        . $strClassName . '" is an object and cannot be converted to a string'
+                    );
+                }
                 settype($jvalue, $type);
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;


### PR DESCRIPTION
Encountered this in a live system; problem is that is throws a PHP level error so on 5.6 this stops script execution unless you write a custom handler. Even with a handler it's hard to determine what was wrong with the JSON.

So this catches a particular combination that will fail and throws a more informative exception.