### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
       "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35",
+        "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
         "squizlabs/php_codesniffer": "~1.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
       "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*",
+        "phpunit/phpunit": "~4.8.35",
         "squizlabs/php_codesniffer": "~1.5"
     }
 }

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -10,6 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once 'JsonMapperTest/Array.php';
 require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/Simple.php';
@@ -23,7 +26,7 @@ require_once 'JsonMapperTest/Simple.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class ArrayTest extends \PHPUnit_Framework_TestCase
+class ArrayTest extends TestCase
 {
     /**
      * Test for an array of classes "@var Classname[]"

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -10,6 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once 'JsonMapperTest/Simple.php';
 require_once 'JsonMapperTest/Object.php';
 require_once 'JsonMapperTest/PlainObject.php';
@@ -25,7 +28,7 @@ require_once 'JsonMapperTest/ComplexObject.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class ObjectTest extends \PHPUnit_Framework_TestCase
+class ObjectTest extends TestCase
 {
     /**
      * Test for a class name "@var Classname"

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -10,6 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/DependencyInjector.php';
 require_once 'JsonMapperTest/Simple.php';
@@ -26,7 +29,7 @@ require_once 'JsonMapperTest/ValueObject.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
-class OtherTest extends \PHPUnit_Framework_TestCase
+class OtherTest extends TestCase
 {
 
     /**

--- a/tests/PHP7_ObjectTest.php
+++ b/tests/PHP7_ObjectTest.php
@@ -11,6 +11,8 @@
  * @link     https://github.com/cweiske/jsonmapper
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Unit tests for JsonMapper's object handling using PHP 7.1 syntax
  *
@@ -21,7 +23,7 @@
  * @link     https://github.com/cweiske/jsonmapper
  * @requires PHP 7.1
  */
-class PHP7_1_ObjectTest extends \PHPUnit_Framework_TestCase
+class PHP7_1_ObjectTest extends TestCase
 {
     /**
      * Sets up test cases loading required classes.

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -10,6 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+
+use PHPUnit\Framework\TestCase;
+
 require_once 'JsonMapperTest/Simple.php';
 
 /**
@@ -21,7 +24,7 @@ require_once 'JsonMapperTest/Simple.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends TestCase
 {
     /**
      * Test for "@var string"

--- a/tests/namespacetest/NamespaceTest.php
+++ b/tests/namespacetest/NamespaceTest.php
@@ -1,5 +1,8 @@
 <?php
 namespace namespacetest;
+
+use PHPUnit\Framework\TestCase;
+
 require_once __DIR__ . '/Unit.php';
 require_once __DIR__ . '/UnitData.php';
 require_once __DIR__ . '/model/MyArrayObject.php';
@@ -7,7 +10,7 @@ require_once __DIR__ . '/model/User.php';
 require_once __DIR__ . '/model/UserList.php';
 require_once __DIR__ . '/../othernamespace/Foo.php';
 
-class NamespaceTest extends \PHPUnit_Framework_TestCase
+class NamespaceTest extends TestCase
 {
     public function testMapArrayNamespace()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.