### PR TITLE
Handle list of ArrayObject instances

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -376,6 +376,13 @@ class JsonMapper
                         );
                     }
                 }
+            } else if ($class == 'ArrayObject'
+                || is_subclass_of($class, 'ArrayObject')
+            ) {
+                $array[$key] = $this->mapArray(
+                    $jvalue,
+                    $this->createInstance($class)
+                );
             } else {
                 $array[$key] = $this->map(
                     $jvalue, $this->createInstance($class)

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -328,6 +328,25 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Lists or ArrayObject instances.
+     */
+    public function testArrayObjectList()
+    {
+        $jm = new JsonMapper();
+        $jm->bStrictNullTypes = false;
+        $sn = $jm->map(
+            json_decode('{"pArrayObjectList": [{"x":"X"},{"y":"Y"}]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertNotNull($sn->pArrayObjectList);
+        $this->assertInternalType('array', $sn->pArrayObjectList);
+        $this->assertEquals(2, count($sn->pArrayObjectList));
+        $ao = $sn->pArrayObjectList[0];
+        $this->assertInstanceOf('ArrayObject', $ao);
+        $this->assertEquals(['x' => 'X'], $ao->getArrayCopy());
+    }
+
+    /**
      * Test for an array of array of integers "@var int[][]"
      */
     public function testNMatrix()

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -10,6 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+
+use namespacetest\model\MyArrayObject;
+
 require_once 'JsonMapperTest/Array.php';
 require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/Simple.php';
@@ -340,9 +343,30 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($sn->pArrayObjectList);
         $this->assertInternalType('array', $sn->pArrayObjectList);
-        $this->assertEquals(2, count($sn->pArrayObjectList));
+        $this->assertCount(2, $sn->pArrayObjectList);
+        $this->assertContainsOnlyInstancesOf(\ArrayObject::class, $sn->pArrayObjectList);
+        // test first element data
         $ao = $sn->pArrayObjectList[0];
-        $this->assertInstanceOf('ArrayObject', $ao);
+        $this->assertEquals(['x' => 'X'], $ao->getArrayCopy());
+    }
+
+    /**
+     * Lists or ArrayObject subclass instances.
+     */
+    public function testArrayObjectSubclassList()
+    {
+        $jm = new JsonMapper();
+        $jm->bStrictNullTypes = false;
+        $sn = $jm->map(
+            json_decode('{"pArrayObjectSubclassList": [{"x":"X"},{"y":"Y"}]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertNotNull($sn->pArrayObjectSubclassList);
+        $this->assertInternalType('array', $sn->pArrayObjectSubclassList);
+        $this->assertCount(2, $sn->pArrayObjectSubclassList);
+        $this->assertContainsOnlyInstancesOf(MyArrayObject::class, $sn->pArrayObjectSubclassList);
+        // test first element data
+        $ao = $sn->pArrayObjectSubclassList[0];
         $this->assertEquals(['x' => 'X'], $ao->getArrayCopy());
     }
 

--- a/tests/JsonMapperTest/Array.php
+++ b/tests/JsonMapperTest/Array.php
@@ -78,6 +78,12 @@ class JsonMapperTest_Array
     public $pSimpleArrayObject;
 
     /**
+     * Array of ArrayObject instances
+     * @var ArrayObject[]
+     */
+    public $pArrayObjectList;
+
+    /**
      * 2D matrix of numbers
      * @var int[][]
      */

--- a/tests/JsonMapperTest/Array.php
+++ b/tests/JsonMapperTest/Array.php
@@ -84,6 +84,12 @@ class JsonMapperTest_Array
     public $pArrayObjectList;
 
     /**
+     * Array of ArrayObject instances
+     * @var \namespacetest\model\MyArrayObject[]
+     */
+    public $pArrayObjectSubclassList;
+
+    /**
      * 2D matrix of numbers
      * @var int[][]
      */


### PR DESCRIPTION
Handle lists of ArrayObject. Object instances are created fine, but not populated without this change.

My real life use case looks something this:
````
class Sub extends \ArrayObject {}
class Results {
    public $foo;
    protected $subs = [];
    /**
     * @param Sub[] $results
     */
    public function setSubs(array $subs) {
        $this->subs = $subs;
    }
}
$json = (object)[
    'foo' => true,
    'subs' => [
        (object)['a'=> 'b', 'c' => 'd'],
        (object)['z' => true]
    ]
];

$mapped = $mapper->map($json, new \Results());
````