### PR TITLE
Fix type error when object is submitted for scalar type field

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -214,7 +214,7 @@ class JsonMapper
                     throw new JsonMapper_Exception(
                         'JSON property "' . $key . '" in class "'
                         . $strClassName . '" is an object and'
-                        . 'cannot be converted to a string'
+                        . ' cannot be converted to a string'
                     );
                 }
                 settype($jvalue, $type);

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -213,7 +213,8 @@ class JsonMapper
                 if (is_object($jvalue) && $type==='string') {
                     throw new JsonMapper_Exception(
                         'JSON property "' . $key . '" in class "'
-                        . $strClassName . '" is an object and cannot be converted to a string'
+                        . $strClassName . '" is an object and'
+                        . 'cannot be converted to a string'
                     );
                 }
                 settype($jvalue, $type);

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -210,6 +210,12 @@ class JsonMapper
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;
             } else if ($this->isSimpleType($type)) {
+                if (is_object($jvalue) && $type==='string') {
+                    throw new JsonMapper_Exception(
+                        'JSON property "' . $key . '" in class "'
+                        . $strClassName . '" is an object and cannot be converted to a string'
+                    );
+                }
                 settype($jvalue, $type);
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;

--- a/tests/JsonMapperTest/Object.php
+++ b/tests/JsonMapperTest/Object.php
@@ -22,6 +22,11 @@ class JsonMapperTest_Object
      */
     public $pPlainObject;
 
+    /**
+     * @var string
+     */
+    public $pString;
+
     public function setNullableObject(JsonMapperTest_PlainObject $obj = null)
     {
         $this->nullableObject = $obj;

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -178,6 +178,22 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test for "@var string" with object value
+     *
+     * @expectedException JsonMapper_Exception
+     * @expectedExceptionMessage JSON property "pString" in class "JsonMapperTest_Object" is an object and cannot be converted to a string
+     */
+    public function testObjectInsteadOfString()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pString":{"key":"val"}}'),
+            new JsonMapperTest_Object()
+        );
+        $this->assertInternalType('null', $sn->pValueObjectNullable);
+    }
+
+    /**
      * Abuse self
      */
     public function __invoke($class, $jvalue)


### PR DESCRIPTION
For an object as follows:

    class Test {
        /**
        * @var string
        */
        public $string;
    }

If the JSON submitted is like: `{"string":{"not":" a string"}}`

Then a PHP level error will occur:

> Object of class stdClass could not be converted to string

This change has a test for and then resolves that issue.
        