### PR TITLE
FIX decoding of "false" is now false

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -217,6 +217,16 @@ class JsonMapper
                         . ' cannot be converted to a string'
                     );
                 }
+                /**
+                 * FIX for PHP LOGIC: bool value "false" is true
+                 * @see http://php.net/manual/en/function.settype.php#107683
+                 */
+                if (($type == 'bool' || $type == 'boolean') &&
+                    trim(strtolower($jvalue)) == 'false')
+                {
+                    $jvalue = false;
+                }
+
                 settype($jvalue, $type);
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -80,6 +80,20 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test for "@var boolean"
+     */
+    public function testMapSimpleBooleanFalse()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pboolean":"false"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('boolean', $sn->pboolean);
+        $this->assertEquals(false, $sn->pboolean);
+    }
+
+    /**
      * Test for "@var int"
      */
     public function testMapSimpleInt()


### PR DESCRIPTION
FIX php bool value of "false" is true - but for json false is expected

if you decode {"obj":"false"} to php, $obj is true before this fix, but false with this fix