### PR TITLE
fix createInstance can't execute constructor when class's constructor without parameters

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -575,7 +575,12 @@ class JsonMapper
         if ($useParameter) {
             return new $class($jvalue);
         } else {
-            return (new ReflectionClass($class))->newInstanceWithoutConstructor();
+            $reflectClass = new ReflectionClass($class);
+            $constructor = $reflectClass->getConstructor();
+            if (null !== $constructor && $constructor->getNumberOfParameters() == 0) {
+                return $reflectClass->newInstance();
+            }
+            return $reflectClass->newInstanceWithoutConstructor();
         }
     }
 

--- a/tests/JsonMapperTest/ObjectConstructorWithoutParam.php
+++ b/tests/JsonMapperTest/ObjectConstructorWithoutParam.php
@@ -1,0 +1,25 @@
+<?php
+
+
+class JsonMapperTest_ObjectConstructorWithoutParam
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    private $rand;
+
+    public function __construct()
+    {
+        $this->rand = mt_rand(1, 10);
+    }
+
+    public function getRand()
+    {
+        return $this->rand;
+    }
+}

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -15,6 +15,7 @@ require_once 'JsonMapperTest/Object.php';
 require_once 'JsonMapperTest/PlainObject.php';
 require_once 'JsonMapperTest/ValueObject.php';
 require_once 'JsonMapperTest/ComplexObject.php';
+require_once 'JsonMapperTest/ObjectConstructorWithoutParam.php';
 
 /**
  * Unit tests for JsonMapper's object handling
@@ -191,6 +192,17 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Object()
         );
         $this->assertInternalType('null', $sn->pValueObjectNullable);
+    }
+
+    public function testConstructorWithoutParams()
+    {
+        $jm = new JsonMapper();
+        $json = '[{"id":1},{"id":2}]';
+        $objs = $jm->mapArray(json_decode($json), [], JsonMapperTest_ObjectConstructorWithoutParam::class);
+
+        array_walk($objs, function (JsonMapperTest_ObjectConstructorWithoutParam $obj) {
+            $this->assertInternalType('int', $obj->getRand());
+        });
     }
 }
 ?>


### PR DESCRIPTION
[#128](https://github.com/cweiske/jsonmapper/issues/128)