### PR TITLE
Fix php 7.4 deprecation notice caused by using curly brackets

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -297,7 +297,7 @@ class JsonMapper
      */
     protected function getFullNamespace($type, $strNs)
     {
-        if ($type === null || $type === '' || $type{0} == '\\'
+        if ($type === null || $type === '' || $type[0] == '\\'
             || $strNs == ''
         ) {
             return $type;


### PR DESCRIPTION
This causes an E_DEPRECATION notice with
`Array and string offset access syntax with curly braces is deprecated`
in the latest in php7.4 builds when JsonMapper.php is autoloaded.

