### PR TITLE
Add missing PHP extension requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/cweiske/jsonmapper/issues"
     },
     "require":{
-      "php": ">=5.6"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,11 @@
         "issues": "https://github.com/cweiske/jsonmapper/issues"
     },
     "require":{
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "ext-spl": "*",
+        "ext-json": "*",
+        "ext-pcre": "*",
+        "ext-reflection": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",


### PR DESCRIPTION
To ensure failing early when trying to build an application with this package with PHP runtime environment missing any of the required extensions it is essential that composer.json has all requirements defined.