### PR TITLE
Add support for snake case conversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -429,6 +429,18 @@ If you do not want this, set ``$bStrictObjectTypeChecking`` to ``true``:
 
 An exception is then thrown in such cases.
 
+Matching snake case keys to camel case properties
+-------------------------------
+When your JSON data uses ``snake_case`` keys you can set
+the ``$bConvertSnakeCase`` flag to ``true`` so properties
+written in ``$camelCase`` will get matched.
+
+.. code:: php
+
+    $jm = new JsonMapper();
+    $jm->bConvertSnakeCase = true;
+    $jm->map(...);
+
 
 Passing arrays to ``map()``
 ---------------------------

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -90,6 +90,14 @@ class JsonMapper
     public $bRemoveUndefinedAttributes = false;
 
     /**
+     * Enable conversion of snake case variables to
+     * camel case.
+     *
+     * @var boolean
+     */
+    public $bConvertSnakeCase = false;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -563,7 +571,9 @@ class JsonMapper
      */
     protected function getSafeName($name)
     {
-        if (strpos($name, '-') !== false) {
+        $convertHyphens = strpos($name, '-') !== false;
+        $convertSnake = $this->bConvertSnakeCase && strpos($name, '_') !== false;
+        if ($convertHyphens || $convertSnake) {
             $name = $this->getCamelCaseName($name);
         }
 

--- a/tests/Options/ConvertSnakeCaseTest.php
+++ b/tests/Options/ConvertSnakeCaseTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Part of JsonMapper
+ *
+ * PHP version 5
+ *
+ * @package  JsonMapper
+ * @author   Christian Weiske <cweiske@cweiske.de>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+require_once __DIR__ . '/../JsonMapperTest/Simple.php';
+
+/**
+ * Unit tests for JsonMapper option "bRemoveUndefinedAttributes".
+ *
+ * @package  JsonMapper
+ * @author   Christian Weiske <cweiske@cweiske.de>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+class Options_ConvertSnakeCaseTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConvertSnakeCase()
+    {
+        $jm = new JsonMapper();
+        $jm->bConvertSnakeCase = true;
+        $obj = $jm->map(
+            json_decode('{"hyphen_value":"abc"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertIsString($obj->hyphenValue);
+        $this->assertFalse(isset($obj->pboolean));
+        $this->assertFalse(isset($obj->pint));
+    }
+}
+?>


### PR DESCRIPTION
Since my frontend usually uses `snake_case_variables` and my classes usually use the `camelCaseNaming` this PR enabled the conversion when matching properties.