### PR TITLE
Support PHP strict property types

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -458,7 +458,7 @@ class JsonMapper
      * Checks property first, falls back to setter method.
      *
      * @param ReflectionClass $rc   Reflection class to check
-     * @param string $name Property name
+     * @param string          $name Property name
      *
      * @return array First value: if the property exists
      *               Second value: the accessor to use (
@@ -539,10 +539,20 @@ class JsonMapper
                     $propTypeName = $rPropType->getName();
 
                     if ($this->isSimpleType($propTypeName)) {
-                        return array(true, $rprop, $propTypeName, $rPropType->allowsNull());
+                        return array(
+                            true,
+                            $rprop,
+                            $propTypeName,
+                            $rPropType->allowsNull()
+                        );
                     }
 
-                    return array(true, $rprop, '\\' . $propTypeName, $rPropType->allowsNull());
+                    return array(
+                        true,
+                        $rprop,
+                        '\\' . $propTypeName,
+                        $rPropType->allowsNull()
+                    );
                 }
                 
                 $docblock    = $rprop->getDocComment();

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -534,10 +534,9 @@ class JsonMapper
         }
         if ($rprop !== null) {
             if ($rprop->isPublic() || $this->bIgnoreVisibility) {
-                if (PHP_MAJOR_VERSION >= 7 && $rprop->hasType()) {
-                    $rPropType = $rprop->getType();
-                    $type = $rPropType->getName();
-                    
+                if (PHP_VERSION_ID >= 70400 && $rprop->hasType()) {
+                    $type = $rprop->getType()->getName();
+
                     return array(true, $rprop, $type);
                 }
                 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -328,9 +328,7 @@ class JsonMapper
      */
     protected function getFullNamespace($type, $strNs)
     {
-        if ($type === null || $type === '' || $type[0] == '\\'
-            || $strNs == ''
-        ) {
+        if ($type === null || $type === '' || $strNs == '' || false !== strpos($type, '\\')) {
             return $type;
         }
         list($first) = explode('[', $type, 2);
@@ -536,6 +534,13 @@ class JsonMapper
         }
         if ($rprop !== null) {
             if ($rprop->isPublic() || $this->bIgnoreVisibility) {
+                if (PHP_MAJOR_VERSION >= 7 && $rprop->hasType()) {
+                    $rPropType = $rprop->getType();
+                    $type = $rPropType->getName();
+                    
+                    return array(true, $rprop, $type);
+                }
+                
                 $docblock    = $rprop->getDocComment();
                 $annotations = $this->parseAnnotations($docblock);
 

--- a/tests/PHP74_StrictTypesTest.php
+++ b/tests/PHP74_StrictTypesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for JsonMapper's support for PHP 7.4 strict types
+ *
+ * @category Tools
+ * @package  JsonMapper
+ * @author   Lukas Cerny <lukas.cerny@futuretek.cz>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     https://github.com/cweiske/jsonmapper
+ * @requires PHP 7.4
+ */
+class PHP74_StrictTypesTest extends \PHPUnit\Framework\TestCase
+{
+    const TEST_DATA = '{"id": 123, "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value"}';
+
+    /**
+     * Sets up test cases loading required classes.
+     *
+     * This is in setUp and not at the top of this file to ensure this is only
+     * executed with PHP 7.4 (due to the `@requires` tag).
+     */
+    protected function setUp()
+    {
+        require_once 'namespacetest/PhpStrictTypes.php';
+        require_once 'namespacetest/model/User.php';
+        require_once 'othernamespace/Foo.php';
+    }
+
+    /**
+     * Test for PHP7.4 strict types.
+     */
+    public function testStrictTypesMapping()
+    {
+        $jm = new JsonMapper();
+        /** @var \namespacetest\PhpStrictTypes $sn */
+        $sn = $jm->map(
+            json_decode(self::TEST_DATA),
+            new \namespacetest\PhpStrictTypes()
+        );
+
+        $this->assertEquals(123, $sn->id);
+        $this->assertInstanceOf(\namespacetest\model\User::class, $sn->importedNs);
+        $this->assertInstanceOf(\othernamespace\Foo::class, $sn->otherNs);
+        $this->assertEquals('anything', $sn->withoutType);
+        $this->assertTrue(isset($sn->nullable));
+    }
+}

--- a/tests/PHP74_StrictTypesTest.php
+++ b/tests/PHP74_StrictTypesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Unit tests for JsonMapper's support for PHP 7.4 strict types
  *

--- a/tests/namespacetest/PhpStrictTypes.php
+++ b/tests/namespacetest/PhpStrictTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace namespacetest;
 
 use namespacetest\model\User;

--- a/tests/namespacetest/PhpStrictTypes.php
+++ b/tests/namespacetest/PhpStrictTypes.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace namespacetest;
+
+use namespacetest\model\User;
+
+class PhpStrictTypes
+{
+    public int $id;
+
+    public User $importedNs;
+
+    public \othernamespace\Foo $otherNs;
+
+    public $withoutType;
+
+    public ?string $nullable;
+}


### PR DESCRIPTION
Hi.

First of all, thank you for this amazing piece of code!

I would like to propose fix for situation where property type is an imported namespaced class.

This fix address the following issues:
* Namespace is not considered when class is imported via use clausule.
* Method `getFullNamespace()` has wrongly checked for namespace separator only on the begining of the $type string.

I would like to discuss another topic. Is there any reason why are phpDoc annotations preffered over `ReflectionProperty->getType()` ? IMHO if property has defined type then this definition should be preffered over user annotation (especially on PHP 7.4 with strict type declaration).

Fix can be tested on PHP 7.4 on the following example:
```
namespace test;

use MongoDB\BSON\ObjectId; //Or any different namespace

class Test {
    /** @var ObjectId Primary key */
    public ObjectId $id;
}
```
