### PR TITLE
Add a filter functionality for JSON keys which could cause problems

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -612,7 +612,7 @@ class JsonMapper
     protected function getFilteredName($name)
     {
         //remove digits on first position
-        $name = ltrim($name, "1 2 3 4 5 6 7 8 9 0" );
+        $name = ltrim($name, "1 2 3 4 5 6 7 8 9 0");
         return preg_replace('/[^A-Za-z0-9\-_]/', '', $name);
     }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -96,7 +96,7 @@ class JsonMapper
      *
      * @var boolean
      */
-    public $bFilterNames = false;
+    public $bSanitizePropertyNames = false;
 
     /**
      * Override class names that JsonMapper uses to create objects.
@@ -591,7 +591,7 @@ class JsonMapper
      */
     protected function getSafeName($name)
     {
-        if($this->bFilterNames === true) {
+        if ($this->bSanitizePropertyNames === true) {
             $name = $this->getFilteredName($name);
         }
 
@@ -605,12 +605,15 @@ class JsonMapper
     /**
      * Removes all invalid characters from the name.
      *
-     * @param string $name
-     * @return string
+     * @param string $name Property name
+     *
+     * @return string Name without special chars
      */
     protected function getFilteredName($name)
     {
-        return preg_replace('/[^A-Za-z\-_]/', '', $name);
+        //remove digits on first position
+        $name = ltrim($name, "1 2 3 4 5 6 7 8 9 0" );
+        return preg_replace('/[^A-Za-z0-9\-_]/', '', $name);
     }
 
     /**

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -90,6 +90,15 @@ class JsonMapper
     public $bRemoveUndefinedAttributes = false;
 
     /**
+     * If you expect strange Keys in the JSON like "1. Information",
+     * you can filter them for proper camel case conversion,
+     * The key "1. Information" result would be "information"
+     *
+     * @var boolean
+     */
+    public $bFilterNames = false;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -582,11 +591,26 @@ class JsonMapper
      */
     protected function getSafeName($name)
     {
+        if($this->bFilterNames === true) {
+            $name = $this->getFilteredName($name);
+        }
+
         if (strpos($name, '-') !== false) {
             $name = $this->getCamelCaseName($name);
         }
 
         return $name;
+    }
+
+    /**
+     * Removes all invalid characters from the name.
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function getFilteredName($name)
+    {
+        return preg_replace('/[^A-Za-z\-_]/', '', $name);
     }
 
     /**

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -231,7 +231,7 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         $jm = new JsonMapper();
         $jm->bSanitizePropertyNames = true;
         $sn = $jm->map(
-            json_decode('{"1, pPlainObject":{"key":"val"}}'),
+            json_decode('{"1. pPlainObject":{"key":"val"}}'),
             new JsonMapperTest_Object()
         );
         $this->assertInternalType('object', $sn->pPlainObject);

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -179,6 +179,8 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInternalType('null', $sn->pValueObjectNullable);
     }
 
+
+
     /**
      * Test for "@var string" with object value
      *
@@ -219,6 +221,33 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertEquals('optional', $objs[0]->foo);
+    }
+
+    /**
+     * Filter for strange key/names on, the object should be mapped correctly
+     */
+    public function testFilterStrangeNamesOn()
+    {
+        $jm = new JsonMapper();
+        $jm->bFilterNames = true;
+        $sn = $jm->map(
+            json_decode('{"1. pPlainObject":{"key":"val"}}'),
+            new JsonMapperTest_Object()
+        );
+        $this->assertInternalType('object', $sn->pPlainObject);
+    }
+
+    /**
+     * Filter for strange key/names off, the object should not be mapped
+     */
+    public function testFilterStrangeNamesOff()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"1. pPlainObject":{"key":"val"}}'),
+            new JsonMapperTest_Object()
+        );
+        $this->assertInternalType('null', $sn->pPlainObject);
     }
 }
 ?>

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -229,9 +229,9 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
     public function testFilterStrangeNamesOn()
     {
         $jm = new JsonMapper();
-        $jm->bFilterNames = true;
+        $jm->bSanitizePropertyNames = true;
         $sn = $jm->map(
-            json_decode('{"1. pPlainObject":{"key":"val"}}'),
+            json_decode('{"1, pPlainObject":{"key":"val"}}'),
             new JsonMapperTest_Object()
         );
         $this->assertInternalType('object', $sn->pPlainObject);


### PR DESCRIPTION
I had a case where the JSON-Keys i got looked like "1. Information", "2. More Information" and so on. Generating php-classes for this is not possible with JsonMapper, so i added a feature where you can filter these names so that the outcome would be "information", "moreInformation"