### PR TITLE
Fix the check that the PHP version is 7.1 or greater

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -499,7 +499,7 @@ class JsonMapper
                         if (is_string($ptype)) {
                             return array(true, $rmeth, $ptype, $isNullable);
                         }
-                        if (PHP_VERSION >= 7.1
+                        if (PHP_VERSION_ID >= 70100
                             && $ptype instanceof ReflectionNamedType
                         ) {
                             return array(


### PR DESCRIPTION
This should use version_compare or PHP_VERSION_ID.
It's already using PHP_VERSION_ID elsewhere.
In php 8.0, `'10.1.2' >= 7.1` is false.