### PR TITLE
Add PHP 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8
 
 before_script:
   - composer install --no-interaction --prefer-source --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0snapshot
+  - nightly
 
 before_script:
   - composer install --no-interaction --prefer-source --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8
+  - 8.0snapshot
 
 before_script:
   - composer install --no-interaction --prefer-source --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - nightly
 
 before_script:
   - composer install --no-interaction --prefer-source --dev

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -477,15 +477,35 @@ class JsonMapper
                 $isNullable = false;
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
-                    $ptype = PHP_MAJOR_VERSION >= 7
-                        ? $rparams[0]->getType() : $rparams[0]->getClass();
                     $isNullable = $rparams[0]->allowsNull();
-                    if ($ptype !== null) {
-                        return array(
-                            true, $rmeth,
-                            '\\' . $ptype,
-                            $isNullable,
-                        );
+                    if (PHP_MAJOR_VERSION >= 7) {
+                        $ptype = $rparams[0]->getType();
+                        if ($ptype !== null) {
+                            if (PHP_VERSION_ID >= 70100
+                                && $ptype instanceof ReflectionNamedType
+                            ) {
+                                $typeName = $ptype->getName();
+                            } else {
+                                $typeName = (string)$ptype;
+                            }
+                            if ($ptype instanceof ReflectionUnionType || !$ptype->isBuiltin()) {
+                                $typeName = '\\' . $typeName;
+                            }
+                            return array(
+                                true, $rmeth,
+                                $typeName,
+                                $isNullable,
+                            );
+                        }
+                    } else {
+                        $pclass = $rparams[0]->getClass();
+                        if ($pclass !== null) {
+                            return array(
+                                true, $rmeth,
+                                '\\' . $pclass->getName(),
+                                $isNullable,
+                            );
+                        }
                     }
                 }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -478,7 +478,7 @@ class JsonMapper
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
                     $isNullable = $rparams[0]->allowsNull();
-                    if (PHP_MAJOR_VERSION >= 7) {
+                    if (PHP_VERSION_ID >= 70000) {
                         $ptype = $rparams[0]->getType();
                         if ($ptype !== null) {
                             if (PHP_VERSION_ID >= 70100
@@ -519,7 +519,7 @@ class JsonMapper
                 if (!isset($annotations['param'][0])) {
                     // If there is no annotations (higher priority) inspect
                     // if there's a scalar type being defined
-                    if (PHP_MAJOR_VERSION >= 7) {
+                    if (PHP_VERSION_ID >= 70000) {
                         $ptype = $rparams[0]->getType();
                         if (is_string($ptype)) {
                             return array(true, $rmeth, $ptype, $isNullable);

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -477,12 +477,12 @@ class JsonMapper
                 $isNullable = false;
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
-                    $pclass = $rparams[0]->getClass();
+                    $ptype = PHP_MAJOR_VERSION >= 7 ? $rparams[0]->getType() : $rparams[0]->getClass();
                     $isNullable = $rparams[0]->allowsNull();
-                    if ($pclass !== null) {
+                    if ($ptype !== null) {
                         return array(
                             true, $rmeth,
-                            '\\' . $pclass->getName(),
+                            '\\' . $ptype,
                             $isNullable,
                         );
                     }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -488,7 +488,9 @@ class JsonMapper
                             } else {
                                 $typeName = (string)$ptype;
                             }
-                            if ($ptype instanceof ReflectionUnionType || !$ptype->isBuiltin()) {
+                            if ($ptype instanceof ReflectionUnionType
+                                || !$ptype->isBuiltin()
+                            ) {
                                 $typeName = '\\' . $typeName;
                             }
                             return array(

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -493,11 +493,13 @@ class JsonMapper
                             ) {
                                 $typeName = '\\' . $typeName;
                             }
-                            return array(
-                                true, $rmeth,
-                                $typeName,
-                                $isNullable,
-                            );
+                            if ($typeName !== 'array') {
+                                return array(
+                                    true, $rmeth,
+                                    $typeName,
+                                    $isNullable,
+                                );
+                            }
                         }
                     } else {
                         $pclass = $rparams[0]->getClass();

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -477,7 +477,8 @@ class JsonMapper
                 $isNullable = false;
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
-                    $ptype = PHP_MAJOR_VERSION >= 7 ? $rparams[0]->getType() : $rparams[0]->getClass();
+                    $ptype = PHP_MAJOR_VERSION >= 7
+                        ? $rparams[0]->getType() : $rparams[0]->getClass();
                     $isNullable = $rparams[0]->allowsNull();
                     if ($ptype !== null) {
                         return array(


### PR DESCRIPTION
`ReflectionParameter::getClass` is deprecated in PHP 8, replaced with `ReflectionParameter::getType` for PHP >= 7.
`ReflectionType::getName()` also changed to implicit `ReflectionType::__toString()`, because `ReflectionUnionType` wont support `getName` method (but anyway union types is not supported, will fail later).