### PR TITLE
PHPUnit 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly
 
 before_script:
   - composer install --no-interaction --prefer-source --dev

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-reflection": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+        "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0 || ~8.0 || ~9.0",
         "squizlabs/php_codesniffer": "~3.5"
     }
 }

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -13,6 +13,7 @@
 
 use namespacetest\model\MyArrayObject;
 
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/Array.php';
 require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/Simple.php';
@@ -30,7 +31,7 @@ require_once 'JsonMapperTest/Zoo/Fish.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class ArrayTest extends \PHPUnit\Framework\TestCase
+class ArrayTest extends TestCase
 {
     /**
      * Test for an array of classes "@var Classname[]"
@@ -42,7 +43,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"typedArray":[{"str":"stringvalue"},{"fl":"1.2"}]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->typedArray);
+        $this->assertIsType('array', $sn->typedArray);
         $this->assertEquals(2, count($sn->typedArray));
         $this->assertInstanceOf('JsonMapperTest_Simple', $sn->typedArray[0]);
         $this->assertInstanceOf('JsonMapperTest_Simple', $sn->typedArray[1]);
@@ -61,7 +62,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"typedSimpleArray":["2014-01-02",null,"2014-05-07"]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->typedSimpleArray);
+        $this->assertIsType('array', $sn->typedSimpleArray);
         $this->assertEquals(3, count($sn->typedSimpleArray));
         $this->assertInstanceOf('DateTime', $sn->typedSimpleArray[0]);
         $this->assertNull($sn->typedSimpleArray[1]);
@@ -105,7 +106,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"flArray":[1.23,3.14,2.048]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->flArray);
+        $this->assertIsType('array', $sn->flArray);
         $this->assertEquals(3, count($sn->flArray));
         $this->assertTrue(is_float($sn->flArray[0]));
         $this->assertTrue(is_float($sn->flArray[1]));
@@ -122,7 +123,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"flArray":{"foo":1.23,"bar":3.14,"baz":2.048}}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->flArray);
+        $this->assertIsType('array', $sn->flArray);
         $this->assertEquals(3, count($sn->flArray));
         $this->assertTrue(is_float($sn->flArray['foo']));
         $this->assertTrue(is_float($sn->flArray['bar']));
@@ -139,11 +140,11 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"strArray":["str",false,2.048]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->strArray);
+        $this->assertIsType('array', $sn->strArray);
         $this->assertEquals(3, count($sn->strArray));
-        $this->assertInternalType('string', $sn->strArray[0]);
-        $this->assertInternalType('string', $sn->strArray[1]);
-        $this->assertInternalType('string', $sn->strArray[2]);
+        $this->assertIsType('string', $sn->strArray[0]);
+        $this->assertIsType('string', $sn->strArray[1]);
+        $this->assertIsType('string', $sn->strArray[2]);
     }
 
     /**
@@ -156,11 +157,11 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"strArrayV2":["str",false,2.048]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->strArrayV2);
+        $this->assertIsType('array', $sn->strArrayV2);
         $this->assertEquals(3, count($sn->strArrayV2));
-        $this->assertInternalType('string', $sn->strArrayV2[0]);
-        $this->assertInternalType('string', $sn->strArrayV2[1]);
-        $this->assertInternalType('string', $sn->strArrayV2[2]);
+        $this->assertIsType('string', $sn->strArrayV2[0]);
+        $this->assertIsType('string', $sn->strArrayV2[1]);
+        $this->assertIsType('string', $sn->strArrayV2[2]);
     }
 
     /**
@@ -215,18 +216,16 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertInstanceOf('ArrayObject', $sn->pSimpleArrayObject);
         $this->assertEquals(2, count($sn->pSimpleArrayObject));
-        $this->assertInternalType('int', $sn->pSimpleArrayObject['eins']);
-        $this->assertInternalType('int', $sn->pSimpleArrayObject['zwei']);
+        $this->assertIsType('int', $sn->pSimpleArrayObject['eins']);
+        $this->assertIsType('int', $sn->pSimpleArrayObject['zwei']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['eins']);
         $this->assertEquals(1, $sn->pSimpleArrayObject['zwei']);
     }
 
-    /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "flArray" must be an array, integer given
-     */
     public function testInvalidArray()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "flArray" must be an array, integer given');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"flArray": 4 }'),
@@ -234,12 +233,10 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pArrayObject" must be an array, double given
-     */
     public function testInvalidArrayObject()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "pArrayObject" must be an array, double given');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"pArrayObject": 4.2 }'),
@@ -262,12 +259,11 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * An ArrayObject which may not be null but is.
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pArrayObject" in class "JsonMapperTest_Array" must not be NULL
      */
     public function testArrayObjectInvalidNull()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "pArrayObject" in class "JsonMapperTest_Array" must not be NULL');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"pArrayObject": null}'),
@@ -346,7 +342,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Array()
         );
         $this->assertNotNull($sn->pArrayObjectList);
-        $this->assertInternalType('array', $sn->pArrayObjectList);
+        $this->assertIsType('array', $sn->pArrayObjectList);
         $this->assertCount(2, $sn->pArrayObjectList);
         $this->assertContainsOnlyInstancesOf(\ArrayObject::class, $sn->pArrayObjectList);
         // test first element data
@@ -366,7 +362,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Array()
         );
         $this->assertNotNull($sn->pArrayObjectSubclassList);
-        $this->assertInternalType('array', $sn->pArrayObjectSubclassList);
+        $this->assertIsType('array', $sn->pArrayObjectSubclassList);
         $this->assertCount(2, $sn->pArrayObjectSubclassList);
         $this->assertContainsOnlyInstancesOf(MyArrayObject::class, $sn->pArrayObjectSubclassList);
         // test first element data
@@ -384,15 +380,15 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"nMatrix":[[1,2],[3,4],[5]]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->nMatrix);
+        $this->assertIsType('array', $sn->nMatrix);
         $this->assertEquals(3, count($sn->nMatrix));
-        $this->assertInternalType('array', $sn->nMatrix[0]);
-        $this->assertInternalType('array', $sn->nMatrix[1]);
-        $this->assertInternalType('array', $sn->nMatrix[2]);
+        $this->assertIsType('array', $sn->nMatrix[0]);
+        $this->assertIsType('array', $sn->nMatrix[1]);
+        $this->assertIsType('array', $sn->nMatrix[2]);
 
         $this->assertEquals(2, count($sn->nMatrix[0]));
-        $this->assertInternalType('int', $sn->nMatrix[0][0]);
-        $this->assertInternalType('int', $sn->nMatrix[0][1]);
+        $this->assertIsType('int', $sn->nMatrix[0][0]);
+        $this->assertIsType('int', $sn->nMatrix[0][1]);
 
         $this->assertEquals(2, count($sn->nMatrix[1]));
         $this->assertEquals(1, count($sn->nMatrix[2]));
@@ -409,13 +405,13 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pMultiverse":[[[{"pint":23}]]]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->pMultiverse);
+        $this->assertIsType('array', $sn->pMultiverse);
         $this->assertEquals(1, count($sn->pMultiverse));
 
-        $this->assertInternalType('array', $sn->pMultiverse[0]);
+        $this->assertIsType('array', $sn->pMultiverse[0]);
         $this->assertEquals(1, count($sn->pMultiverse[0]));
 
-        $this->assertInternalType('array', $sn->pMultiverse[0][0]);
+        $this->assertIsType('array', $sn->pMultiverse[0][0]);
         $this->assertEquals(1, count($sn->pMultiverse[0][0]));
 
         $this->assertInstanceOf(
@@ -460,7 +456,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
             json_decode('{"typedSimpleArray":{"en-US":"2014-01-02"}}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->typedSimpleArray);
+        $this->assertIsType('array', $sn->typedSimpleArray);
         $this->assertEquals(1, count($sn->typedSimpleArray));
         $this->assertArrayHasKey('en-US', $sn->typedSimpleArray);
         $this->assertInstanceOf('DateTime', $sn->typedSimpleArray['en-US']);
@@ -471,18 +467,17 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for "@var string[]" with object value
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "strArray" is an array of type "string" but contained a value of type "object"
      */
     public function testObjectInsteadOfString()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "strArray" is an array of type "string" but contained a value of type "object"');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"strArray":[{}]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $sn->strArray);
+        $this->assertIsType('array', $sn->strArray);
         $this->assertNotEmpty($sn->strArray);
     }
 

--- a/tests/ClassMapTest.php
+++ b/tests/ClassMapTest.php
@@ -10,6 +10,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/Simple.php';
 require_once 'JsonMapperTest/Object.php';
 require_once 'JsonMapperTest/PlainObject.php';
@@ -25,7 +26,7 @@ require_once 'JsonMapperTest/ComplexObject.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class ClassMapTest extends \PHPUnit\Framework\TestCase
+class ClassMapTest extends TestCase
 {
     /**
      * Abuse self
@@ -73,7 +74,7 @@ class ClassMapTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Object()
         );
 
-        $this->assertInternalType('object', $sn->pPlainObject);
+        $this->assertIsType('object', $sn->pPlainObject);
         $this->assertInstanceOf('DateTime', $sn->pPlainObject);
         $this->assertEquals(
             self::CLASS_MAP_DATA,
@@ -116,7 +117,7 @@ class ClassMapTest extends \PHPUnit\Framework\TestCase
             new \namespacetest\UnitData()
         );
 
-        $this->assertInternalType('string', $data->user);
+        $this->assertIsType('string', $data->user);
     }
 
     public function testMapArraySubtype()
@@ -127,9 +128,9 @@ class ClassMapTest extends \PHPUnit\Framework\TestCase
             json_decode('{"typedSimpleArray":["2019-03-23"]}'),
             new JsonMapperTest_Array()
         );
-        $this->assertInternalType('array', $data->typedSimpleArray);
+        $this->assertIsType('array', $data->typedSimpleArray);
         $this->assertEquals(1, count($data->typedSimpleArray));
-        $this->assertInternalType('string', $data->typedSimpleArray[0]);
+        $this->assertIsType('string', $data->typedSimpleArray[0]);
     }
 }
 ?>

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -10,9 +10,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-
-use PHPUnit\Framework\TestCase;
-
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/EventObject.php';
 
 /**
@@ -40,7 +38,7 @@ class EventTest extends TestCase
             json_decode('{"pStr":"one"}', false),
             new JsonMapperTest_EventObject()
         );
-        $this->assertInternalType('string', $sn->pStr);
+        $this->assertIsType('string', $sn->pStr);
         $this->assertEquals('two', $sn->pStr);
     }
 }

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -10,6 +10,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/Simple.php';
 require_once 'JsonMapperTest/Object.php';
 require_once 'JsonMapperTest/PlainObject.php';
@@ -27,7 +28,7 @@ require_once 'JsonMapperTest/ObjectConstructorOptional.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class ObjectTest extends \PHPUnit\Framework\TestCase
+class ObjectTest extends TestCase
 {
     /**
      * Test for a class name "@var Classname"
@@ -39,7 +40,7 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
             json_decode('{"simple":{"str":"stringvalue"}}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('object', $sn->simple);
+        $this->assertIsType('object', $sn->simple);
         $this->assertInstanceOf('JsonMapperTest_Simple', $sn->simple);
         $this->assertEquals('stringvalue', $sn->simple->str);
     }
@@ -105,17 +106,15 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Object()
         );
 
-        $this->assertInternalType('object', $sn->pPlainObject);
+        $this->assertIsType('object', $sn->pPlainObject);
         $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn->pPlainObject);
         $this->assertEquals('abc', $sn->pPlainObject->pStr);
     }
 
-    /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pValueObject" must be an object, string given
-     */
     public function testStrictTypeCheckingObjectError()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "pValueObject" must be an object, string given');
         $jm = new JsonMapper();
         $jm->bStrictObjectTypeChecking = true;
         $sn = $jm->map(
@@ -165,34 +164,32 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for "@var object" with null value
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pValueObject" in class "JsonMapperTest_Object" must not be NULL
      */
     public function testObjectInvalidNull()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "pValueObject" in class "JsonMapperTest_Object" must not be NULL');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"pValueObject":null}'),
             new JsonMapperTest_Object()
         );
-        $this->assertInternalType('null', $sn->pValueObjectNullable);
+        $this->assertIsType('null', $sn->pValueObjectNullable);
     }
 
     /**
      * Test for "@var string" with object value
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "pString" in class "JsonMapperTest_Object" is an object and cannot be converted to a string
      */
     public function testObjectInsteadOfString()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "pString" in class "JsonMapperTest_Object" is an object and cannot be converted to a string');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"pString":{"key":"val"}}'),
             new JsonMapperTest_Object()
         );
-        $this->assertInternalType('null', $sn->pValueObjectNullable);
+        $this->assertIsType('null', $sn->pValueObjectNullable);
     }
 
     public function testConstructorWithoutParams()

--- a/tests/ObjectTest_PHP7.php
+++ b/tests/ObjectTest_PHP7.php
@@ -10,6 +10,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+require_once 'TestCase.php';
 
 /**
  * Unit tests for JsonMapper's object handling using PHP 7.1 syntax
@@ -19,9 +20,9 @@
  * @author   Christian Weiske <cweiske@cweiske.de>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
- * @requires PHP 7.1
+ * @requires PHP >= 7.1
  */
-class PHP7_1_ObjectTest extends \PHPUnit\Framework\TestCase
+class ObjectTest_PHP7 extends TestCase
 {
     /**
      * Sets up test cases loading required classes.
@@ -29,7 +30,7 @@ class PHP7_1_ObjectTest extends \PHPUnit\Framework\TestCase
      * This is in setUp and not at the top of this file to ensure this is only
      * executed with PHP 7.1 (due to the `@requires` tag).
      */
-    protected function setUp()
+    protected function setUp(): void
     {
        require_once 'JsonMapperTest/PlainObject.php';
        require_once 'JsonMapperTest/PHP7_Object.php';
@@ -49,12 +50,11 @@ class PHP7_1_ObjectTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for non-nullable types like "@param object" with null value
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "nonNullableObject" in class "JsonMapperTest_PHP7_Object" must not be NULL
      */
     public function testObjectSetterDocblockInvalidNull()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "nonNullableObject" in class "JsonMapperTest_PHP7_Object" must not be NULL');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"nonNullableObject":null}'),

--- a/tests/Options/RemoveUndefinedAttributesTest.php
+++ b/tests/Options/RemoveUndefinedAttributesTest.php
@@ -9,6 +9,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
+require_once __DIR__ . '/../TestCase.php';
 require_once __DIR__ . '/../JsonMapperTest/Simple.php';
 
 /**
@@ -19,7 +20,7 @@ require_once __DIR__ . '/../JsonMapperTest/Simple.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
-class Options_RemoveUndefinedAttributesTest extends \PHPUnit\Framework\TestCase
+class Options_RemoveUndefinedAttributesTest extends TestCase
 {
     public function testRemoveUndefinedAttributes()
     {

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -9,6 +9,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/DependencyInjector.php';
 require_once 'JsonMapperTest/Simple.php';
@@ -25,37 +26,31 @@ require_once 'JsonMapperTest/ValueObject.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     http://cweiske.de/
  */
-class OtherTest extends \PHPUnit\Framework\TestCase
+class OtherTest extends TestCase
 {
-
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage JsonMapper::map() requires first argument to be an object, NULL given.
-     */
     public function testMapNullJson()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('JsonMapper::map() requires first argument to be an object, NULL given.');
         $jm = new JsonMapper();
         $sn = $jm->map(null, new JsonMapperTest_Simple());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage JsonMapper::map() requires second argument to be an object, NULL given.
-     */
     public function testMapNullObject()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('JsonMapper::map() requires second argument to be an object, NULL given.');
         $jm = new JsonMapper();
         $sn = $jm->map(new stdClass(), null);
     }
 
     /**
      * Test for "@var "
-     *
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage Empty type at property "JsonMapperTest_Simple::$empty"
      */
     public function testMapEmpty()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('Empty type at property "JsonMapperTest_Simple::$empty"');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode(
@@ -77,7 +72,7 @@ class OtherTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Simple()
         );
 
-        $this->assertInternalType('object', $sn->internalData['typehint']);
+        $this->assertIsType('object', $sn->internalData['typehint']);
         $this->assertInstanceOf(
             'JsonMapperTest_Simple', $sn->internalData['typehint']
         );
@@ -97,7 +92,7 @@ class OtherTest extends \PHPUnit\Framework\TestCase
             json_decode('{"simpleSetterOnlyDocblock":{"str":"stringvalue"}}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('object', $sn->internalData['docblock']);
+        $this->assertIsType('object', $sn->internalData['docblock']);
         $this->assertInstanceOf(
             'JsonMapperTest_Simple', $sn->internalData['docblock']
         );
@@ -116,7 +111,7 @@ class OtherTest extends \PHPUnit\Framework\TestCase
             json_decode('{"simpleSetterOnlyNoType":{"str":"stringvalue"}}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('object', $sn->internalData['notype']);
+        $this->assertIsType('object', $sn->internalData['notype']);
         $this->assertInstanceOf(
             'stdClass', $sn->internalData['notype']
         );
@@ -137,7 +132,7 @@ class OtherTest extends \PHPUnit\Framework\TestCase
             json_decode('{"protectedStrNoSetter":"stringvalue"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('null', $sn->getProtectedStrNoSetter());
+        $this->assertIsType('null', $sn->getProtectedStrNoSetter());
         $this->assertEquals(
             array(
                 array(
@@ -153,12 +148,10 @@ class OtherTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage Required property "pMissingData" of class JsonMapperTest_Broken is missing in JSON data
-     */
     public function testMissingDataException()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('Required property "pMissingData" of class JsonMapperTest_Broken is missing in JSON data');
         $jm = new JsonMapper();
         $jm->bExceptionOnMissingData = true;
         $sn = $jm->map(
@@ -181,12 +174,10 @@ class OtherTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "undefinedProperty" does not exist in object of type JsonMapperTest_Broken
-     */
     public function testUndefinedPropertyException()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "undefinedProperty" does not exist in object of type JsonMapperTest_Broken');
         $jm = new JsonMapper();
         $jm->bExceptionOnUndefinedProperty = true;
         $sn = $jm->map(
@@ -226,12 +217,10 @@ class OtherTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(empty($logger->log));
     }
 
-    /**
-     * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "privateNoSetter" has no public setter method in object of type PrivateWithSetter
-     */
     public function testPrivatePropertyWithNoSetter()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "privateNoSetter" has no public setter method in object of type PrivateWithSetter');
         $jm = new JsonMapper();
         $jm->bExceptionOnUndefinedProperty = true;
         $logger = new JsonMapperTest_Logger();
@@ -266,12 +255,10 @@ class OtherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $result->getPrivateNoSetter());
     }
 
-    /**
-     * @expectedException        JsonMapper_Exception
-     * @expectedExceptionMessage JSON property "privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter
-     */
     public function testPrivatePropertyWithPrivateSetter()
     {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter');
         $jm = new JsonMapper();
         $jm->bExceptionOnUndefinedProperty = true;
         $logger = new JsonMapperTest_Logger();
@@ -369,7 +356,7 @@ class OtherTest extends \PHPUnit\Framework\TestCase
             json_decode('{"setterPreferredOverProperty":"foo"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('string', $sn->setterPreferredOverProperty);
+        $this->assertIsType('string', $sn->setterPreferredOverProperty);
         $this->assertEquals(
             'set via setter: foo', $sn->setterPreferredOverProperty
         );

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -10,6 +10,7 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+require_once 'TestCase.php';
 require_once 'JsonMapperTest/Simple.php';
 
 /**
@@ -21,7 +22,7 @@ require_once 'JsonMapperTest/Simple.php';
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-class SimpleTest extends \PHPUnit\Framework\TestCase
+class SimpleTest extends TestCase
 {
     /**
      * Test for "@var string"
@@ -33,7 +34,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"str":"stringvalue"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('string', $sn->str);
+        $this->assertIsType('string', $sn->str);
         $this->assertEquals('stringvalue', $sn->str);
     }
 
@@ -47,7 +48,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"fl":"1.2"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('float', $sn->fl);
+        $this->assertIsType('float', $sn->fl);
         $this->assertEquals(1.2, $sn->fl);
     }
 
@@ -61,7 +62,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pbool":"1"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('boolean', $sn->pbool);
+        $this->assertIsType('boolean', $sn->pbool);
         $this->assertEquals(true, $sn->pbool);
     }
 
@@ -75,7 +76,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pboolean":"0"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('boolean', $sn->pboolean);
+        $this->assertIsType('boolean', $sn->pboolean);
         $this->assertEquals(false, $sn->pboolean);
     }
 
@@ -89,7 +90,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pint":"123"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('integer', $sn->pint);
+        $this->assertIsType('integer', $sn->pint);
         $this->assertEquals(123, $sn->pint);
     }
 
@@ -103,7 +104,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pinteger":"12345"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('integer', $sn->pinteger);
+        $this->assertIsType('integer', $sn->pinteger);
         $this->assertEquals(12345, $sn->pinteger);
     }
 
@@ -117,14 +118,14 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"mixed":12345}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('integer', $sn->mixed);
+        $this->assertIsType('integer', $sn->mixed);
         $this->assertEquals('12345', $sn->mixed);
 
         $sn = $jm->map(
             json_decode('{"mixed":"12345"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('string', $sn->mixed);
+        $this->assertIsType('string', $sn->mixed);
         $this->assertEquals(12345, $sn->mixed);
     }
 
@@ -138,7 +139,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pnullable":0}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('integer', $sn->pnullable);
+        $this->assertIsType('integer', $sn->pnullable);
         $this->assertEquals(0, $sn->pnullable);
     }
 
@@ -152,7 +153,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pnullable":null}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('null', $sn->pnullable);
+        $this->assertIsType('null', $sn->pnullable);
         $this->assertEquals(null, $sn->pnullable);
     }
 
@@ -166,7 +167,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"pnullable":"12345"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('integer', $sn->pnullable);
+        $this->assertIsType('integer', $sn->pnullable);
         $this->assertEquals(12345, $sn->pnullable);
     }
 
@@ -180,7 +181,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"notype":{"k":"v"}}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('object', $sn->notype);
+        $this->assertIsType('object', $sn->notype);
         $this->assertEquals((object) array('k' => 'v'), $sn->notype);
     }
 
@@ -194,7 +195,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"under_score":"f"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType('string', $sn->under_score);
+        $this->assertIsType('string', $sn->under_score);
         $this->assertEquals('f', $sn->under_score);
     }
 
@@ -209,7 +210,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"under_score_setter":"blubb"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType(
+        $this->assertIsType(
             'string', $sn->internalData['under_score_setter']
         );
         $this->assertEquals(
@@ -228,7 +229,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Simple()
         );
 
-        $this->assertInternalType('string', $sn->hyphenValue);
+        $this->assertIsType('string', $sn->hyphenValue);
         $this->assertEquals('test', $sn->hyphenValue);
 
     }
@@ -243,7 +244,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             json_decode('{"hyphen-value-setter":"blubb"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertInternalType(
+        $this->assertIsType(
             'string', $sn->internalData['hyphen-value-setter']
         );
         $this->assertEquals(

--- a/tests/StrictTypesTest_PHP7.php
+++ b/tests/StrictTypesTest_PHP7.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once 'TestCase.php';
+
 /**
  * Unit tests for JsonMapper's support for PHP 7.4 strict types
  *
@@ -8,9 +10,9 @@
  * @author   Lukas Cerny <lukas.cerny@futuretek.cz>
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
- * @requires PHP 7.4
+ * @requires PHP >= 7.4
  */
-class PHP74_StrictTypesTest extends \PHPUnit\Framework\TestCase
+class StrictTypesTest_PHP7 extends TestCase
 {
     const TEST_DATA = '{"id": 123, "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value", "fooArray": [{"name": "Foo 1"}, {"name": "Foo 2"}]}';
 
@@ -20,7 +22,7 @@ class PHP74_StrictTypesTest extends \PHPUnit\Framework\TestCase
      * This is in setUp and not at the top of this file to ensure this is only
      * executed with PHP 7.4 (due to the `@requires` tag).
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         require_once 'namespacetest/PhpStrictTypes.php';
         require_once 'namespacetest/model/User.php';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Asserts that a variable is of a given type.
+     *
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertIsType($expected, $actual, $message = '')
+    {
+        $constraint = class_exists(\PHPUnit\Framework\Constraint\IsType::class)
+            ? new \PHPUnit\Framework\Constraint\IsType($expected)
+            : new \PHPUnit_Framework_Constraint_IsType($expected);
+
+        static::assertThat($actual, $constraint, $message);
+    }
+}

--- a/tests/namespacetest/NamespaceTest.php
+++ b/tests/namespacetest/NamespaceTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace namespacetest;
+require_once __DIR__ . '/../TestCase.php';
 require_once __DIR__ . '/Unit.php';
 require_once __DIR__ . '/UnitData.php';
 require_once __DIR__ . '/model/MyArrayObject.php';
@@ -7,7 +8,7 @@ require_once __DIR__ . '/model/User.php';
 require_once __DIR__ . '/model/UserList.php';
 require_once __DIR__ . '/../othernamespace/Foo.php';
 
-class NamespaceTest extends \PHPUnit\Framework\TestCase
+class NamespaceTest extends \TestCase
 {
     public function testMapArrayNamespace()
     {
@@ -74,12 +75,10 @@ class NamespaceTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\namespacetest\model\User', $res->user);
     }
 
-    /**
-     * @expectedException JsonMapper_Exception
-     * @expectedExceptionMessage Empty type at property "namespacetest\UnitData::$empty"
-     */
     public function testMapEmpty()
     {
+        $this->expectException(\JsonMapper_Exception::class);
+        $this->expectExceptionMessage('Empty type at property "namespacetest\UnitData::$empty"');
         $mapper = new \JsonMapper();
         $json = '{"empty":{}}';
         /* @var \namespacetest\UnitData $res */
@@ -103,7 +102,7 @@ class NamespaceTest extends \PHPUnit\Framework\TestCase
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
         $this->assertInstanceOf('\namespacetest\model\MyArrayObject', $res->aodata);
-        $this->assertInternalType('string', $res->aodata[0]);
+        $this->assertIsType('string', $res->aodata[0]);
         $this->assertEquals('foo', $res->aodata[0]);
     }
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,6 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
 >
+    <testsuites>
+        <testsuite name="My Test Suite">
+            <directory suffix="Test.php">.</directory>
+            <directory suffix="Test_PHP7.php" phpVersion="7.0.0" phpVersionOperator=">=">.</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist>
             <directory suffix=".php">../src/</directory>


### PR DESCRIPTION
PHP 5.6 and earlier PHPUnit versions still supported.
Previous version of this PR (#171) was closed because it was complete mess.