### PR TITLE
Fixing ReflectionUnionType handling on PHP 8.0

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -453,6 +453,13 @@ class JsonMapper
         return $array;
     }
 
+    /**
+     * Converts a ReflectionType to a string representation
+     *
+     * @param ReflectionType $type
+     *
+     * @return string
+     */
     protected function stringifyReflectionType(\ReflectionType $type) : string
     {
         if ($type instanceof ReflectionNamedType) {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -456,7 +456,7 @@ class JsonMapper
     /**
      * Converts a ReflectionType to a string representation
      *
-     * @param ReflectionType $type
+     * @param ReflectionType $type The type to stringify
      *
      * @return string
      */

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -453,13 +453,20 @@ class JsonMapper
         return $array;
     }
 
-    protected function stringifyReflectionType(\ReflectionType $type) : string{
+    protected function stringifyReflectionType(\ReflectionType $type) : string
+    {
         if ($type instanceof ReflectionNamedType) {
             $typeName = ($type->isBuiltin() ? "" : '\\') . $type->getName();
-        } elseif (PHP_VERSION_ID >= 80000 && $type instanceof ReflectionUnionType) {
-            $typeName = implode("|", array_map(function(ReflectionNamedType $type) : string{
-                return ($type->isBuiltin() ? "" : "\\") . $type->getName();
-            }, $type->getTypes()));
+        } elseif (PHP_VERSION_ID >= 80000
+            && $type instanceof ReflectionUnionType
+        ) {
+            $typeName = implode(
+                "|", array_map(
+                    function (ReflectionNamedType $type) : string {
+                        return ($type->isBuiltin() ? "" : "\\") . $type->getName();
+                    }, $type->getTypes()
+                )
+            );
         } else {
             throw new \AssertionError("Unreachable");
         }


### PR DESCRIPTION
This and various other issues were found using [PHPStan](https://github.com/phpstan/phpstan).

Other issues found are minor issues, but this one is serious and will cause crashes if native union types are encountered.

Judging by the fact that the tests passed both before and after these changes, I guess there isn't any tests for native unions...