### PR TITLE
[In progress] Resolves array-of-object checks when object is provided instead

### DIFF
--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -51,6 +51,28 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * A typed array should be an array of items, but if provided an object it should error
+     * In the example given the JSON shows an object but PHP will see this still as an
+     * array (given it does not have a separate list type) so the mapper should error
+     * if strict type checking is enabled
+     */
+    public function testTypedArrayFailsWithObject()
+    {
+        $jm = new JsonMapper();
+        $jm->bStrictObjectTypeChecking = true;
+        try {
+            $sn = $jm->map(
+                json_decode('{"typedArray":{"str":"stringvalue"}}'),
+                new JsonMapperTest_Array()
+            );
+            $this->fail('The mapper should throw an exception when an invalid object is passed as a list. Result was: '.json_encode($sn));
+        }
+        catch (InvalidArgumentException $e){
+            $this->assertStringContainsStringIgnoringCase('type', $e->getMessage());
+        }
+    }
+
+    /**
      * Test for an array of classes "@var ClassName[]" with
      * flat/simple json values (string)
      */


### PR DESCRIPTION
In the event where a field is declared as an "array of object" e.g.

```
/** @var SomeObject[] */
public $field;
```

The following JSON would be expected (assuming it matched the definition of `SomeObject`):

```
{"field": [{"key": "value"}, {"key": "other-value"}]}
```

It would also be valid to do:

```
{"field": []}
```

However it would not be valid to do:

```
{"field": {"key": "value"}}
```
As this defines the value of field to be itself an object.

At present, as far as I can see using the `master` branch, JSON Mapper will not error for the above condition. This will result in the field `field` being set to an array of newly instantiated objects of the defined type and disregarding the content of the provided data altogether.

This poses risks for APIs where a base object may set values to 0 or empty strings, i.e. it assumes it's initialising or resetting a row rather than that the input was incorrect. It is debateable whether this should be an error in base working mode, but if `bStrictObjectTypeChecking` is enabled then it definitely should be, as an object-like-array is definitively not the same as a list of objects of a given type.

This PR currently contains a test fail showing the issue; I'd be happy to expand to pass the test if it is thought that the test case is valid.