### PR TITLE
Added condition for checking snake case symbol.

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -601,7 +601,7 @@ class JsonMapper
      */
     protected function getSafeName($name)
     {
-        if (strpos($name, '-') !== false) {
+        if (strpos($name, '-') !== false || strpos($name, '_') !== false) {
             $name = $this->getCamelCaseName($name);
         }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -611,8 +611,9 @@ class JsonMapper
     {
         $isRenameToCamelCase = strpos($name, '-') !== false;
 
-        if($this->bUnderScoreToSnakeCase) {
-            $isRenameToCamelCase = $isRenameToCamelCase || strpos($name, '_') !== false;
+        if ($this->bUnderScoreToSnakeCase) {
+            $isRenameToCamelCase = $isRenameToCamelCase
+                || strpos($name, '_') !== false;
         }
 
         if ($isRenameToCamelCase) {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -48,6 +48,14 @@ class JsonMapper
     public $bExceptionOnMissingData = false;
 
     /**
+     * If the json key written in snakeCase,
+     * than jsonMapper will map to class property in camelCase.
+     *
+     * @var boolean
+     */
+    public $bUnderScoreToSnakeCase = false;
+
+    /**
      * If the types of map() parameters shall be checked.
      *
      * You have to disable it if you're using the json_decode "assoc" parameter.
@@ -601,7 +609,13 @@ class JsonMapper
      */
     protected function getSafeName($name)
     {
-        if (strpos($name, '-') !== false || strpos($name, '_') !== false) {
+        $isRenameToCamelCase = strpos($name, '-') !== false;
+
+        if($this->bUnderScoreToSnakeCase){
+            $isRenameToCamelCase = $isRenameToCamelCase || strpos($name, '_') !== false;
+        }
+
+        if ($isRenameToCamelCase) {
             $name = $this->getCamelCaseName($name);
         }
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -611,7 +611,7 @@ class JsonMapper
     {
         $isRenameToCamelCase = strpos($name, '-') !== false;
 
-        if($this->bUnderScoreToSnakeCase){
+        if($this->bUnderScoreToSnakeCase) {
             $isRenameToCamelCase = $isRenameToCamelCase || strpos($name, '_') !== false;
         }
 

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -32,6 +32,20 @@ require_once 'JsonMapperTest/Zoo/Fish.php';
  */
 class ArrayTest extends \PHPUnit\Framework\TestCase
 {
+    public function testMapArrayWithKeysInSnakeCase(){
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"typed_array":[{"str":"stringvalue"},{"fl":"1.2"}]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertIsArray($sn->typedArray);
+        $this->assertEquals(2, count($sn->typedArray));
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn->typedArray[0]);
+        $this->assertInstanceOf('JsonMapperTest_Simple', $sn->typedArray[1]);
+        $this->assertEquals('stringvalue', $sn->typedArray[0]->str);
+        $this->assertEquals(1.2, $sn->typedArray[1]->fl);
+    }
+
     /**
      * Test for an array of classes "@var Classname[]"
      */

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -34,6 +34,7 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
 {
     public function testMapArrayWithKeysInSnakeCase(){
         $jm = new JsonMapper();
+        $jm->bUnderScoreToSnakeCase = true;
         $sn = $jm->map(
             json_decode('{"typed_array":[{"str":"stringvalue"},{"fl":"1.2"}]}'),
             new JsonMapperTest_Array()


### PR DESCRIPTION
I've tried to map an array where the keys are written in a snake case into classes where the properties are written in a camel case, and I noticed that jsonmapper can't do that.

Looked at the source code, found that the check for "_" is just not there.