### PR TITLE
Update the autoload mapping for composer to use classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Map nested JSON structures onto PHP classes",
     "license": "OSL-3.0",
     "autoload": {
-        "psr-0": {"JsonMapper": "src/"}
+        "classmap": ["src/"]
     },
     "authors": [
         {


### PR DESCRIPTION
There's a side effect of composer that I'd consider a bug, which defaults to use PEAR like standards for autoloading classes, even if the classes are registered as PSR0. Since this codebase doesn't follow the PSR0 standard, I have updated the composer file to use the `classmap` method instead.

I have confirmed that the two files provided by this codebase are still loaded and are available.

For some background, I'm writing something that turns paths into classes based on the data within composers autoloader, and this package consistently broke it because it is expected to be PSR0, and composer loaded it regardless.