### PR TITLE
[Feature] Mapping to camel case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -386,6 +386,28 @@ __ http://php.net/manual/en/language.types.callable.php
     $jm->undefinedPropertyHandler = 'setUndefinedProperty';
     $jm->map(...);
 
+Or if you would let JsonMapper handle the setter for you, you can return a string
+from the ``$undefinedPropertyHandler`` which will be used as property name.
+
+.. code:: php
+
+    /**
+     * Handle undefined properties during JsonMapper::map()
+     *
+     * @param object $object    Object that is being filled
+     * @param string $propName  Name of the unknown JSON property
+     * @param mixed  $jsonValue JSON value of the property
+     *
+     * @return void
+     */
+    function fixPropName($object, $propName, $jsonValue)
+    {
+        return ucfirst($propName);
+    }
+
+    $jm = new JsonMapper();
+    $jm->undefinedPropertyHandler = 'fixPropName';
+    $jm->map(...);
 
 Missing properties
 ------------------

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -90,14 +90,6 @@ class JsonMapper
     public $bRemoveUndefinedAttributes = false;
 
     /**
-     * If property is not found by its json key name, try to find the property
-     * by converting the key name to camel case.
-     *
-     * @var boolean
-     */
-    public $bMatchPropertyByCamelCase = false;
-
-    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -533,14 +525,6 @@ class JsonMapper
                 if ((strcasecmp($p->name, $name) === 0)) {
                     $rprop = $p;
                     break;
-                }
-
-                if ($this->bMatchPropertyByCamelCase) {
-                    $camelCaseName = $this->getCamelCaseName($name);
-                    if ((strcasecmp($p->name, $camelCaseName) === 0)) {
-                        $rprop = $p;
-                        break;
-                    }
                 }
             }
         }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -75,7 +75,7 @@ class JsonMapper
     public $bStrictNullTypes = true;
 
     /**
-     * Allow mapping of private and proteted properties.
+     * Allow mapping of private and protected properties.
      *
      * @var boolean
      */

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -177,10 +177,15 @@ class JsonMapper
                         . ' in object of type ' . $strClassName
                     );
                 } else if ($this->undefinedPropertyHandler !== null) {
-                    call_user_func(
+                    $undefinedPropertyKey = call_user_func(
                         $this->undefinedPropertyHandler,
                         $object, $key, $jvalue
                     );
+
+                    if (is_string($undefinedPropertyKey)) {
+                        list($hasProperty, $accessor, $type, $isNullable)
+                            = $this->inspectProperty($rc, $undefinedPropertyKey);
+                    }
                 } else {
                     $this->log(
                         'info',
@@ -188,7 +193,10 @@ class JsonMapper
                         array('property' => $key, 'class' => $strClassName)
                     );
                 }
-                continue;
+
+                if (!$hasProperty) {
+                    continue;
+                }
             }
 
             if ($accessor === null) {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -90,6 +90,14 @@ class JsonMapper
     public $bRemoveUndefinedAttributes = false;
 
     /**
+     * If property is not found by its json key name, try to find the property
+     * by converting the key name to camel case.
+     *
+     * @var boolean
+     */
+    public $bMatchPropertyByCamelCase = false;
+
+    /**
      * Override class names that JsonMapper uses to create objects.
      * Useful when your setter methods accept abstract classes or interfaces.
      *
@@ -525,6 +533,14 @@ class JsonMapper
                 if ((strcasecmp($p->name, $name) === 0)) {
                     $rprop = $p;
                     break;
+                }
+
+                if ($this->bMatchPropertyByCamelCase) {
+                    $camelCaseName = $this->getCamelCaseName($name);
+                    if ((strcasecmp($p->name, $camelCaseName) === 0)) {
+                        $rprop = $p;
+                        break;
+                    }
                 }
             }
         }

--- a/tests/NameMappingTest.php
+++ b/tests/NameMappingTest.php
@@ -8,10 +8,20 @@ require_once 'JsonMapperTest/Simple.php';
 
 class NameMappingTest extends TestCase
 {
-    public function testItMapsKeyByCamelCaseName(): void
+    public function testItSetKeysIfReturnedByUndefinedPropertyHandler(): void
     {
         $jm = new JsonMapper();
-        $jm->bMatchPropertyByCamelCase = true;
+        $jm->undefinedPropertyHandler = function (
+            JsonMapperTest_Simple $object,
+            string $key,
+            $value
+        ): string {
+            return lcfirst(
+                str_replace(
+                    ' ', '', ucwords(str_replace(array('_', '-'), ' ', $key))
+                )
+            );
+        };
 
         /** @var JsonMapperTest_Simple $sn */
         $sn = $jm->map(
@@ -22,9 +32,14 @@ class NameMappingTest extends TestCase
         self::assertSame('abc', $sn->hyphenValue);
     }
 
-    public function testItDoesNotMapKeyByCamelCaseNameIfFlagIsNotSet(): void
+    public function testItDoesNotMapKeyIfUndefinedPropertyHandlerDoesNotReturnValue(): void
     {
         $jm = new JsonMapper();
+        $jm->undefinedPropertyHandler = function (
+            JsonMapperTest_Simple $object,
+            string $key,
+            $value
+        ): void {};
 
         /** @var JsonMapperTest_Simple $sn */
         $sn = $jm->map(

--- a/tests/NameMappingTest.php
+++ b/tests/NameMappingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once 'JsonMapperTest/Simple.php';
+
+class NameMappingTest extends TestCase
+{
+    public function testItMapsKeyByCamelCaseName(): void
+    {
+        $jm = new JsonMapper();
+        $jm->bMatchPropertyByCamelCase = true;
+
+        /** @var JsonMapperTest_Simple $sn */
+        $sn = $jm->map(
+            json_decode('{"hyphen_value": "abc"}'),
+            new JsonMapperTest_Simple()
+        );
+
+        self::assertSame('abc', $sn->hyphenValue);
+    }
+
+    public function testItDoesNotMapKeyByCamelCaseNameIfFlagIsNotSet(): void
+    {
+        $jm = new JsonMapper();
+
+        /** @var JsonMapperTest_Simple $sn */
+        $sn = $jm->map(
+            json_decode('{"hyphen_value": "abc"}'),
+            new JsonMapperTest_Simple()
+        );
+
+        self::assertNull($sn->hyphenValue);
+    }
+}


### PR DESCRIPTION
### UseCase

I have a API which I consume and I want to map this to objects. 

With PHP8.1 you have the wonderful support of readonly properties.

```
public readonly string $categoryId;
```

This works actual perfect with the json mapper and reduces the amount of boilerplate code to near zero. 

My problem is, that the API I consume, often uses snake_case names and because of that I have to add setter functions to the model class. This leads to errors because you can not reset the property with a setter if it is a readonly property. There for I have to make it private and add a getter. All the boilerplate code is back. 

### Suggestion

So my suggestions is to add a new flag to support converting property keys to camelCase if they are not found. 

I am not really confident with the naming so I am open for a better naming.

If you are fine with this I would add it to the readme to explain the usage.  