### PR TITLE
add handling for associative array declaration

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -567,9 +567,9 @@ class JsonMapper
                 )
                 ) {
                     $type = trim($matches['type']) . '[]';
-                    $isNullable1 = $this->isNullable($annotations['var'][0]);
+                    $isNullable = $this->isNullable($annotations['var'][0]);
 
-                    return array(true, $rprop, $type, $isNullable1 );
+                    return array(true, $rprop, $type, $isNullable);
                 }
 
                 //support "@var type description"

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -559,6 +559,13 @@ class JsonMapper
                     return array(true, $rprop, null, false);
                 }
 
+                //support key-based arrays, i.e. "array<string, string>"
+                if (preg_match('/array<(?<keyType>[^,]+),(?<type>[^>]+)>/', $annotations['var'][0], $matches)) {
+                    $type = trim($matches['type']) . '[]';
+
+                    return array(true, $rprop, $type, $this->isNullable($annotations['var'][0]));
+                }
+
                 //support "@var type description"
                 list($type) = explode(' ', $annotations['var'][0]);
 

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -560,10 +560,16 @@ class JsonMapper
                 }
 
                 //support key-based arrays, i.e. "array<string, string>"
-                if (preg_match('/array<(?<keyType>[^,]+),(?<type>[^>]+)>/', $annotations['var'][0], $matches)) {
+                if (preg_match(
+                    '/array<(?<keyType>[^,]+),(?<type>[^>]+)>/',
+                    $annotations['var'][0],
+                    $matches
+                )
+                ) {
                     $type = trim($matches['type']) . '[]';
+                    $isNullable1 = $this->isNullable($annotations['var'][0]);
 
-                    return array(true, $rprop, $type, $this->isNullable($annotations['var'][0]));
+                    return array(true, $rprop, $type, $isNullable1 );
                 }
 
                 //support "@var type description"

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -465,6 +465,35 @@ class ArrayTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Map a JSON object to an array with an associative key.
+     */
+    public function testMapArrayWithAssociativeKey()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pStringKeyedArray": {"foo": {"pbool": true}}}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertIsArray($sn->pStringKeyedArray);
+        $this->assertEquals(1, count($sn->pStringKeyedArray));
+        $this->assertArrayHasKey('foo', $sn->pStringKeyedArray);
+        $this->assertInstanceOf(JsonMapperTest_Simple::class, $sn->pStringKeyedArray['foo']);
+        $this->assertTrue(
+            $sn->pStringKeyedArray['foo']->pbool
+        );
+    }
+
+    public function testMapArrayWithAssociativeKeyAndNull()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pIntKeyedArrayAndNull": null}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertNull($sn->pIntKeyedArrayAndNull);
+    }
+
+    /**
      * Test for "@var string[]" with object value
      */
     public function testObjectInsteadOfString()

--- a/tests/JsonMapperTest/Array.php
+++ b/tests/JsonMapperTest/Array.php
@@ -98,5 +98,15 @@ class JsonMapperTest_Array
      * @var JsonMapperTest_Simple[][][]
      */
     public $pMultiverse;
+
+    /**
+     * @var array<string, JsonMapperTest_Simple>
+     */
+    public $pStringKeyedArray;
+
+    /**
+     * @var array<int, JsonMapperTest_Simple>|null
+     */
+    public $pIntKeyedArrayAndNull;
 }
 ?>


### PR DESCRIPTION
I think I like this library a little bit too much <3 

I would love to have support for associative arrays because that way we could handle some usecases where an external api sends us an object with different now known keys. 

Of course I could simply use a `stdClass` but that would lead to the whole object be only a `stdClass`. 

With this implementation I could map the objects to their corresponding classes and therefore have a wonderful object tree.

Any suggestions on that? 

