### PR TITLE
Enforce strict type checks for at least primitive values

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -67,6 +67,15 @@ class JsonMapper
     public $bStrictObjectTypeChecking = false;
 
     /**
+     * Throw an exception when JSON contains ill-typed primitive value
+     *
+     * @note Useful only with PHP 7.4+
+     *
+     * @var boolean
+     */
+    public $bStrictPrimitiveTypeChecking = false;
+
+    /**
      * Throw an exception, if null value is found
      * but the type of attribute does not allow nulls.
      *
@@ -237,7 +246,9 @@ class JsonMapper
                         . ' cannot be converted to a string'
                     );
                 }
-                settype($jvalue, $type);
+                if (!$this->bStrictPrimitiveTypeChecking) {
+                    settype($jvalue, $type);
+                }
                 $this->setProperty($object, $accessor, $jvalue);
                 continue;
             }

--- a/tests/StrictTypes_PHP74_Test.php
+++ b/tests/StrictTypes_PHP74_Test.php
@@ -13,6 +13,7 @@
 class StrictTypes_PHP74_Test extends \PHPUnit\Framework\TestCase
 {
     const TEST_DATA = '{"id": 123, "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value", "fooArray": [{"name": "Foo 1"}, {"name": "Foo 2"}]}';
+    const BROKEN_TEST_DATA = '{"id": "asdf", "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value", "fooArray": [{"name": "Foo 1"}, {"name": "Foo 2"}]}';
 
     /**
      * Sets up test cases loading required classes.
@@ -48,5 +49,18 @@ class StrictTypes_PHP74_Test extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $sn->fooArray);
         $this->assertInstanceOf(\othernamespace\Foo::class, $sn->fooArray[0]);
         $this->assertInstanceOf(\othernamespace\Foo::class, $sn->fooArray[1]);
+    }
+
+    public function testStrictTypesMappingFail()
+    {
+        $this->expectException(TypeError::class);
+
+        $jm = new JsonMapper();
+        $jm->bStrictPrimitiveTypeChecking = true;
+        /** @var \namespacetest\PhpStrictTypes $sn */
+        $sn = $jm->map(
+            json_decode(self::BROKEN_TEST_DATA),
+            new \namespacetest\PhpStrictTypes()
+        );
     }
 }


### PR DESCRIPTION
Fix #202 