### PR TITLE
Pass on the parent json values to the mapped class

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -233,7 +233,7 @@ class JsonMapper
             }
 
             $type = $this->getFullNamespace($type, $strNs);
-            $type = $this->getMappedType($type, $jvalue, $pvalue);
+            $type = $this->getMappedType($type, $jvalue, $json);
 
             if ($type === null || $type === 'mixed') {
                 //no given type - simply set the json data
@@ -429,7 +429,7 @@ class JsonMapper
     {
         $originalClass = $class;
         foreach ($json as $key => $jvalue) {
-            $class = $this->getMappedType($originalClass, $jvalue, $pvalue);
+            $class = $this->getMappedType($originalClass, $jvalue, $json);
             if ($class === null) {
                 $array[$key] = $jvalue;
             } else if ($this->isArrayOfType($class)) {
@@ -693,7 +693,7 @@ class JsonMapper
      *
      * @return string The mapped type/class name
      */
-    protected function getMappedType($type, $jvalue = null, $pvalue = null)
+    protected function getMappedType($type, $jvalue = null, $pjson = null)
     {
         if (isset($this->classMap[$type])) {
             $target = $this->classMap[$type];
@@ -707,7 +707,7 @@ class JsonMapper
 
         if ($target) {
             if (is_callable($target)) {
-                $type = $target($type, $jvalue, $pvalue);
+                $type = $target($type, $jvalue, $pjson);
             } else {
                 $type = $target;
             }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -233,7 +233,7 @@ class JsonMapper
             }
 
             $type = $this->getFullNamespace($type, $strNs);
-            $type = $this->getMappedType($type, $jvalue);
+            $type = $this->getMappedType($type, $jvalue, $pvalue);
 
             if ($type === null || $type === 'mixed') {
                 //no given type - simply set the json data
@@ -429,7 +429,7 @@ class JsonMapper
     {
         $originalClass = $class;
         foreach ($json as $key => $jvalue) {
-            $class = $this->getMappedType($originalClass, $jvalue);
+            $class = $this->getMappedType($originalClass, $jvalue, $pvalue);
             if ($class === null) {
                 $array[$key] = $jvalue;
             } else if ($this->isArrayOfType($class)) {
@@ -693,7 +693,7 @@ class JsonMapper
      *
      * @return string The mapped type/class name
      */
-    protected function getMappedType($type, $jvalue = null)
+    protected function getMappedType($type, $jvalue = null, $pvalue = null)
     {
         if (isset($this->classMap[$type])) {
             $target = $this->classMap[$type];
@@ -707,7 +707,7 @@ class JsonMapper
 
         if ($target) {
             if (is_callable($target)) {
-                $type = $target($type, $jvalue);
+                $type = $target($type, $jvalue, $pvalue);
             } else {
                 $type = $target;
             }


### PR DESCRIPTION
Pass on the parent json values to the mapped class

I'm required to be able to read the parent JSON object for the passed object.
This is a simple solution for this.

Example

```
$mapper = function($object, $body, $parent) {
 if($parent->type == "Type1") {
   if($body->version == 1)  return '\MyClassType1v1';
 }
};
$jm->classMap[\MyClass::class] = $mapper;
```

