### PR TITLE
Custom array key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -514,6 +514,22 @@ Now ``afterMapping()`` is called on each mapped object
 (if the class has that method).
 
 
+Custom array key
+================
+JsonMapper can call a custom method that returns the array key for each object:
+
+.. code:: php
+
+    $jm = new JsonMapper();
+    $jm->arrayKeyMethod = 'getId';
+    $jm->map(...);
+
+Now ``arrayKeyMethod()`` is called on each mapped object
+(if the class has that method) to use it as the key for the array.
+
+In case a key is not unique, an exception is thrown.
+
+
 ============
 Installation
 ============

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -577,6 +577,37 @@ JSON;
             '2014-05-07', $variadicArray[1]->format('Y-m-d')
         );
     }
+
+    public function testCustomArrayKeyMethod()
+    {
+        $jm = new JsonMapper();
+        $jm->arrayKeyMethod = 'getPint';
+        $sn = $jm->map(
+            json_decode('{"typedArray": [{"pint": 2, "str":"X"},{"pint": 4, "str":"Y"}]}'),
+            new JsonMapperTest_Array()
+        );
+        $this->assertNotNull($sn->typedArray);
+        $this->assertIsArray($sn->typedArray);
+        $this->assertCount(2, $sn->typedArray);
+        $this->assertContainsOnlyInstancesOf(JsonMapperTest_Simple::class, $sn->typedArray);
+        // Check that the correct array keys have been used
+        $this->assertEquals([2, 4], array_keys($sn->typedArray));
+        // Check that the correct value has been assigned
+        $this->assertEquals('X', $sn->typedArray[2]->str);
+    }
+
+    public function testCustomArrayKeyMethodException()
+    {
+        // The key "2" is used twice, so this will throw an exception
+        $this->expectException(JsonMapper_Exception::class);
+
+        $jm = new JsonMapper();
+        $jm->arrayKeyMethod = 'getPint';
+        $sn = $jm->map(
+            json_decode('{"typedArray": [{"pint": 2, "str":"X"},{"pint": 2, "str":"Y"}]}'),
+            new JsonMapperTest_Array()
+        );
+    }
 }
 
 ?>

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -157,5 +157,11 @@ class JsonMapperTest_Simple
     {
         $this->valueObject = $valueObject;
     }
+
+    public function getPint()
+    {
+        return $this->pint;
+    }
+
 }
 ?>


### PR DESCRIPTION
I implemented a way to call a method on each object in an array to use as the array key.

Example: Given the following JSON code:

```json
{ "categories": [{"id": 3, "title": "..."}, {"id": 10, "title": "..."}, {"id": 42, "title": "..."}], "otherKey": "..." }
```

and the following mapping:
```php
class Data {
    /**
     * @var Category
     */
    public array $categories;
}

class Category {
    public $id;
    public $title;
    public function getId() {
        return $this->id
    }
}
```

Then the mapper could be called like this:

```php
$jsonMapper = new JsonMapper();
$jsonMapper->arrayKeyMethod = 'getId';
$data = $jsonMapper->map($data, new Data());
```

The $categories array will now contain elements with keys 3, 10 and 42 instead of 0, 1 and 2.