### PR TITLE
Fixed E_* warnings generated by arrays and objects assigned to scalars

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -245,11 +245,11 @@ class JsonMapper
             } else if ($this->isSimpleType($type)
                 && !(is_array($jvalue) && $this->hasVariadicArrayType($accessor))
             ) {
-                if ($type === 'string' && is_object($jvalue)) {
+                if ($this->isFlatType($type) && !$this->isFlatType(gettype($jvalue))) {
                     throw new JsonMapper_Exception(
                         'JSON property "' . $key . '" in class "'
-                        . $strClassName . '" is an object and'
-                        . ' cannot be converted to a string'
+                        . $strClassName . '" is of type ' . gettype($jvalue) . ' and'
+                        . ' cannot be converted to ' . $type
                     );
                 }
                 settype($jvalue, $type);

--- a/tests/JsonMapperTest/ArrayValueForStringProperty.php
+++ b/tests/JsonMapperTest/ArrayValueForStringProperty.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Part of JsonMapper
+ *
+ * PHP version 5
+ *
+ * @package  JsonMapper
+ * @author   Christian Weiske <cweiske@cweiske.de>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     http://cweiske.de/
+ */
+
+class JsonMapperTest_ArrayValueForStringProperty
+{
+	public string $value;
+}

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -194,7 +194,7 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
     public function testObjectInsteadOfString()
     {
         $this->expectException(JsonMapper_Exception::class);
-        $this->expectExceptionMessage('JSON property "pString" in class "JsonMapperTest_Object" is an object and cannot be converted to a string');
+        $this->expectExceptionMessage('JSON property "pString" in class "JsonMapperTest_Object" is of type object and cannot be converted to string');
         $jm = new JsonMapper();
         $sn = $jm->map(
             json_decode('{"pString":{"key":"val"}}'),

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -10,7 +10,9 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
+
 require_once 'JsonMapperTest/Simple.php';
+require_once 'JsonMapperTest/ArrayValueForStringProperty.php';
 
 /**
  * Unit tests for JsonMapper's simple type handling
@@ -246,6 +248,16 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
             'blubb', $sn->internalData['hyphen-value-setter']
         );
 
+    }
+
+    public function testMapArrayValueToStringProperty()
+    {
+        $jm = new JsonMapper();
+        $this->expectException(JsonMapper_Exception::class);
+        $jm->map(
+            json_decode('{"value":[]}'),
+            new JsonMapperTest_ArrayValueForStringProperty()
+        );
     }
 }
 ?>

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -10,7 +10,6 @@
  * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
  * @link     https://github.com/cweiske/jsonmapper
  */
-
 require_once 'JsonMapperTest/Simple.php';
 require_once 'JsonMapperTest/ArrayValueForStringProperty.php';
 

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -254,6 +254,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
     {
         $jm = new JsonMapper();
         $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "value" in class "JsonMapperTest_ArrayValueForStringProperty" is of type array and cannot be converted to string');
         $jm->map(
             json_decode('{"value":[]}'),
             new JsonMapperTest_ArrayValueForStringProperty()


### PR DESCRIPTION
The included test case should explain the problem.

I don't know what the correct fix for this is right now.

Side note: Several of the tests don't work so well on PHP 8.2, generating dynamic property deprecation warnings.