### PR TITLE
php 8.0 constructor property promotion with array and associated annotation

### DIFF
--- a/tests/Array_PHP80_Test.php
+++ b/tests/Array_PHP80_Test.php
@@ -28,7 +28,7 @@ class Array_PHP80_Test extends TestCase
         $jsonMapper = new \JsonMapper();
         $jsonMapper->bIgnoreVisibility = true;
         $array = $jsonMapper->map($json, PHP80_Array::class);
-        self::assertCount(1, $array->files);
-        self::assertInstanceOf(JsonMapperTest_ArrayValueForStringProperty::class, $array->files[0]);
+        self::assertCount(1, $array->getFiles());
+        self::assertInstanceOf(JsonMapperTest_ArrayValueForStringProperty::class, $array->getFiles()[0]);
     }
 }

--- a/tests/Array_PHP80_Test.php
+++ b/tests/Array_PHP80_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for JsonMapper's support for PHP 8.0 typed arrays for properties with constructor promotion
+ *
+ * @category Tools
+ * @package  JsonMapper
+ * @author   Andreas Wunderwald <wundii@gmail.com>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     https://github.com/cweiske/jsonmapper
+ * @requires PHP 8.0
+ */
+class Array_PHP80_Test extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once 'JsonMapperTest/PHP80_Array.php';
+        require_once 'JsonMapperTest/ArrayValueForStringProperty.php';
+    }
+
+    public function testJsonMapper()
+    {
+        $json = json_decode('{"files": [{"value":"test.txt"}]}');
+        $jsonMapper = new \JsonMapper();
+        $jsonMapper->bIgnoreVisibility = true;
+        $array = $jsonMapper->map($json, PHP80_Array::class);
+        self::assertCount(1, $array->files);
+        self::assertInstanceOf(JsonMapperTest_ArrayValueForStringProperty::class, $array->files[0]);
+    }
+}

--- a/tests/JsonMapperTest/PHP80_Array.php
+++ b/tests/JsonMapperTest/PHP80_Array.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class PHP80_Array
+{
+    /**
+     * @param JsonMapperTest_ArrayValueForStringProperty[] $files
+     */
+    public function __construct(
+        public array $files,
+    ) {
+    }
+}

--- a/tests/JsonMapperTest/PHP80_Array.php
+++ b/tests/JsonMapperTest/PHP80_Array.php
@@ -8,7 +8,15 @@ class PHP80_Array
      * @param JsonMapperTest_ArrayValueForStringProperty[] $files
      */
     public function __construct(
-        public array $files,
+        private array $files,
     ) {
+    }
+
+    /**
+     * @return JsonMapperTest_ArrayValueForStringProperty[]
+     */
+    public function getFiles(): array
+    {
+        return $this->files;
     }
 }


### PR DESCRIPTION
The is an extension of JsonMapper for Php 8 to include constructor property promotion with array and associated annotation. 

Starting from php 8 version there is constructor property promotion. The reflection always only reads the overlying annotation from the respective property. As soon as you use the new php 8 notation with the constructor, I wrote a small extension. If the read annotation from the reflection class is empty and php greater than 8.0 is used and there exists a constructor, then get this annotation and search there the right element based on the requested variable. 

With this extension, the entities can be built much cleaner in php8, if the properties should be private and readonly.

The unit test are passing.