### PR TITLE
Enhancing postMappingMethod with Additional Arguments

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -129,6 +129,13 @@ class JsonMapper
     public $postMappingMethod = null;
 
     /**
+     * Optional arguments that are passed to the post mapping method
+     *
+     * @var array
+     */
+    public $postMappingMethodArguments = array();
+
+    /**
      * Map data all data in $json into the given $object instance.
      *
      * @param object|array        $json   JSON object structure from json_decode()
@@ -337,7 +344,7 @@ class JsonMapper
                 $this->postMappingMethod
             );
             $refDeserializePostMethod->setAccessible(true);
-            $refDeserializePostMethod->invoke($object);
+            $refDeserializePostMethod->invoke($object, ...$this->postMappingMethodArguments);
         }
 
         return $object;

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -43,5 +43,19 @@ class EventTest extends TestCase
         $this->assertIsString($sn->pStr);
         $this->assertEquals('two', $sn->pStr);
     }
+
+    public function testDeserializePostEventArguments()
+    {
+        $jm = new JsonMapper();
+        $jm->postMappingMethod = '_deserializePostEventWithArguments';
+        $jm->postMappingMethodArguments = array(3, 'bar');
+        /** @var JsonMapperTest_EventObject $sn */
+        $sn = $jm->map(
+            json_decode('{"pStr":"one"}', false),
+            new JsonMapperTest_EventObject()
+        );
+        $this->assertIsString($sn->pStr);
+        $this->assertEquals('barbarbar', $sn->pStr);
+    }
 }
 ?>

--- a/tests/JsonMapperTest/EventObject.php
+++ b/tests/JsonMapperTest/EventObject.php
@@ -10,5 +10,14 @@ class JsonMapperTest_EventObject
     {
         $this->pStr = 'two';
     }
+
+    /**
+     * @param int $arg1
+     * @param string $arg2
+     */
+    private function _deserializePostEventWithArguments($arg1, $arg2)
+    {
+        $this->pStr = str_repeat($arg2, $arg1);
+    }
 }
 ?>


### PR DESCRIPTION
This pull request aims to address the need for accessing supplementary data within the post mapping method by introducing a new feature - `postMappingMethodArguments`. This enhancement allows users to pass an array of values that will be made available when invoking the post mapping method.

Your feedback and insights on this proposed enhancement are highly appreciated.

resolves #217 