### PR TITLE
Fix error when reading classes with a mixed property

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -357,7 +357,7 @@ class JsonMapper
             return $type;
         }
         list($first) = explode('[', $type, 2);
-        if ($first === 'mixed' || $this->isSimpleType($first)) {
+        if ($this->isSimpleType($first)) {
             return $type;
         }
 
@@ -734,7 +734,8 @@ class JsonMapper
             || $type == 'boolean' || $type == 'bool'
             || $type == 'integer' || $type == 'int'
             || $type == 'double' || $type == 'float'
-            || $type == 'array' || $type == 'object';
+            || $type == 'array' || $type == 'object'
+            || $type === 'mixed';
     }
 
     /**
@@ -756,7 +757,7 @@ class JsonMapper
 
     /**
      * Checks if the given type is a type that is not nested
-     * (simple type except array and object)
+     * (simple type except array, object and mixed)
      *
      * @param string $type type name from gettype()
      *

--- a/tests/MixedType_PHP80_Test.php
+++ b/tests/MixedType_PHP80_Test.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Unit tests for JsonMapper's support for PHP 8.0 mixed type
+ *
+ * @category Tools
+ * @package  JsonMapper
+ * @author   Lukas Cerny <lukas.cerny@futuretek.cz>
+ * @license  OSL-3.0 http://opensource.org/licenses/osl-3.0
+ * @link     https://github.com/cweiske/jsonmapper
+ * @requires PHP 8.0
+ */
+class MixedType_PHP80_Test extends \PHPUnit\Framework\TestCase
+{
+    const TEST_DATA_COMPLEX = '{"data": { "id": 123, "name": "Test User" }}';
+    const TEST_DATA_SIMPLE = '{"data": 123}';
+
+    /**
+     * Sets up test cases loading required classes.
+     *
+     * This is in setUp and not at the top of this file to ensure this is only
+     * executed with PHP 8.0 (due to the `@requires` tag).
+     */
+    protected function setUp(): void
+    {
+        require_once 'namespacetest/PhpMixedType.php';
+    }
+
+    /**
+     * Test for PHP 8.0 mixed type containing an object.
+     */
+    public function testStrictTypesMapping_ComplexValue()
+    {
+        $jm = new JsonMapper();
+        /** @var \namespacetest\PhpMixedType $sn */
+        $sn = $jm->map(
+            json_decode(self::TEST_DATA_COMPLEX),
+            new \namespacetest\PhpMixedType()
+        );
+
+        $this->assertInstanceOf(stdClass::class, $sn->data);
+        $this->assertEquals(123, $sn->data->id);
+        $this->assertEquals('Test User', $sn->data->name);
+    }
+
+    /**
+     * Test for PHP 8.0 mixed type containing an int.
+     */
+    public function testStrictTypesMapping_SimpleValue()
+    {
+        $jm = new JsonMapper();
+        /** @var \namespacetest\PhpMixedType $sn */
+        $sn = $jm->map(
+            json_decode(self::TEST_DATA_SIMPLE),
+            new \namespacetest\PhpMixedType()
+        );
+
+        $this->assertEquals(123, $sn->data);
+    }
+}

--- a/tests/namespacetest/PhpMixedType.php
+++ b/tests/namespacetest/PhpMixedType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace namespacetest;
+
+class PhpMixedType
+{
+    public mixed $data;
+}


### PR DESCRIPTION
I created an object with a property with type 'mixed', as is possible since PHP 8.0.

Unfortunately, this doesn't work, despite various checks in the code for `$type === 'mixed'`. It malfunctions in my case when mixed is not used as an annotation. but as a PHP property type. Around line 571 a namespace prefix is added because mixed is not recognized as a simple type.

This PR fixes that and adds a test.