### PR TITLE
Update .gitattributes to ignore all non-runtime files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,9 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.travis.yml export-ignore
 /ChangeLog export-ignore
 /example export-ignore
-/package.xml export-ignore
 /README.rst export-ignore
 /tests export-ignore
+/.editorconfig export-ignore
+/.github export-ignore
+/contributing.rst export-ignore


### PR DESCRIPTION
When working on #219 I noticed that .gitattributes wasn't updated since 2017 and some of the files listed don't exist anymore. Also, some new files that are not needed in the Composer package were added since then.