### PR TITLE
Fix crash for property with case difference and without docblock

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -553,6 +553,7 @@ class JsonMapper
             foreach ($rc->getProperties() as $p) {
                 if ((strcasecmp($p->name, $name) === 0)) {
                     $rprop = $p;
+                    $class = $rc;
                     break;
                 }
             }

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -65,6 +65,9 @@ class JsonMapperTest_Simple
      */
     public $notype;
 
+    // Intentionally no docblock
+    public $nodocblock;
+
     /**
      * @var string A protected property without a setter method
      */

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -247,5 +247,20 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
         );
 
     }
+
+    /**
+     * Variable with hyphen and a setter method
+     */
+    public function testMapCaseMismatch()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"nodocblock":"blubb"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertIsString($sn->nodocblock);
+        $this->assertEquals('blubb', $sn->nodocblock);
+
+    }
 }
 ?>


### PR DESCRIPTION
7dc32f56b5dc8ee064a726f4642a8a66ac90509c introduced a possible crash under a very specific situation:

1. A property is matched with a case difference.
2. The property has no docblock

In this situation, the following crash occurs:

```
Error: Call to a member function hasMethod() on bool[0] (caught throwable) at /var/www/admin/vendor/netresearch/jsonmapper/src/JsonMapper.php line 564.
```

The reason is that inside `inspectProperty()`, `$class` is null when the property is not found by exact name. Later, the code attempts to find the property case-insensitively, but then `$class` is left `false`. This leads to a crash in new code introduced by 7dc32f56b5dc8ee064a726f4642a8a66ac90509c.

The attached patch contains a test that fails when the change in `JsonMapper.php` is not applied.