### PR TITLE
Fixed bStrictObjectTypeChecking not enforced for array elements

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -461,6 +461,13 @@ class JsonMapper
                         settype($jvalue, $class);
                         $array[$key] = $jvalue;
                     } else {
+                        if ($this->bStrictObjectTypeChecking) {
+                            throw new JsonMapper_Exception(
+                                'JSON property "' . ($parent_key ? $parent_key : '?') . '"'
+                                . ' (array key "' . $key . '") must be an object, '
+                                . gettype($jvalue) . ' given'
+                            );
+                        }
                         $array[$key] = $this->createInstance(
                             $class, true, $jvalue
                         );

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -463,7 +463,8 @@ class JsonMapper
                     } else {
                         if ($this->bStrictObjectTypeChecking) {
                             throw new JsonMapper_Exception(
-                                'JSON property "' . ($parent_key ? $parent_key : '?') . '"'
+                                'JSON property'
+                                . ' "' . ($parent_key ? $parent_key : '?') . '"'
                                 . ' (array key "' . $key . '") must be an object, '
                                 . gettype($jvalue) . ' given'
                             );

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -134,6 +134,34 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testStrictTypeCheckingObjectInArray()
+    {
+        $jm = new JsonMapper();
+        $jm->bStrictObjectTypeChecking = true;
+        $sn = $jm->mapArray(
+            json_decode('[{"pStr":"abc"}]'),
+            [],
+            JsonMapperTest_PlainObject::class
+        );
+
+        $this->assertIsObject($sn[0]);
+        $this->assertInstanceOf('JsonMapperTest_PlainObject', $sn[0]);
+        $this->assertEquals('abc', $sn[0]->pStr);
+    }
+
+    public function testStrictTypeCheckingObjectInArrayError()
+    {
+        $this->expectException(JsonMapper_Exception::class);
+        $this->expectExceptionMessage('JSON property "?" (array key "0") must be an object, string given');
+        $jm = new JsonMapper();
+        $jm->bStrictObjectTypeChecking = true;
+        $jm->mapArray(
+            json_decode('["abc"]'),
+            [],
+            JsonMapperTest_Object::class
+        );
+    }
+
     /**
      * Test for "@var object|null" with null value
      */


### PR DESCRIPTION
this created some security issues in my projects.

Might be worth having createInstance() check if the object in question has any @required properties.
In the second case, the model's @required properties wouldn't be populated, but no error would be thrown.
This makes it a requirement to use `bStrictObjectTypeChecking` in any security-conscious situation, but it wasn't considered at all in the case of arrays.