### PR TITLE
Support shorter ?Type syntax for nullable types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,9 +251,9 @@ Supported type names
    - ``Suit:string|Suit:int`` - exception will be thrown if the JSON value is not present in the enum
 - Nullable types:
 
-  - ``int|null`` - will be ``null`` if the value in JSON is
+  - ``int|null`` or ``?int`` - will be ``null`` if the value in JSON is
     ``null``, otherwise it will be an integer
-  - ``Contact|null`` - will be ``null`` if the value in JSON is
+  - ``Contact|null`` or ``?Contact`` - will be ``null`` if the value in JSON is
     ``null``, otherwise it will be an object of type ``Contact``
 
 ArrayObjects and extending classes are treated as arrays.
@@ -327,7 +327,7 @@ parameters into the call.
 Nullables
 ---------
 JsonMapper throws an exception when a JSON property is ``null``,
-unless the PHP class property has a nullable type - e.g. ``Contact|null``.
+unless the PHP class property has a nullable type - e.g. ``Contact|null`` or ``?Contact``.
 
 If your API contains many fields that may be ``null`` and you do not want
 to make all your type definitions nullable, set:

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -855,7 +855,8 @@ class JsonMapper
      */
     protected function isNullable($type)
     {
-        return stripos('|' . $type . '|', '|null|') !== false;
+        return stripos('|' . $type . '|', '|null|') !== false
+            || strpos('|' . $type, '|?') !== false;
     }
 
     /**
@@ -871,7 +872,7 @@ class JsonMapper
             return null;
         }
         return substr(
-            str_ireplace('|null|', '|', '|' . $type . '|'),
+            str_ireplace(['|null|', '|?'], '|', '|' . $type . '|'),
             1, -1
         );
     }

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -134,39 +134,81 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
-            json_decode('{"pnullable":0}'),
+            json_decode('{"pnullableint":0}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertIsInt($sn->pnullable);
-        $this->assertEquals(0, $sn->pnullable);
+        $this->assertIsInt($sn->pnullableint);
+        $this->assertEquals(0, $sn->pnullableint);
     }
 
     /**
      * Test for "@var int|null" with null value
      */
-    public function testMapSimpleNullableNull()
+    public function testMapSimpleNullableIntNull()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
-            json_decode('{"pnullable":null}'),
+            json_decode('{"pnullableint":null}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertNull($sn->pnullable);
-        $this->assertEquals(null, $sn->pnullable);
+        $this->assertNull($sn->pnullableint);
+        $this->assertEquals(null, $sn->pnullableint);
     }
 
     /**
      * Test for "@var int|null" with string value
      */
-    public function testMapSimpleNullableWrong()
+    public function testMapSimpleNullableIntWrong()
     {
         $jm = new JsonMapper();
         $sn = $jm->map(
-            json_decode('{"pnullable":"12345"}'),
+            json_decode('{"pnullableint":"12345"}'),
             new JsonMapperTest_Simple()
         );
-        $this->assertIsInt($sn->pnullable);
-        $this->assertEquals(12345, $sn->pnullable);
+        $this->assertIsInt($sn->pnullableint);
+        $this->assertEquals(12345, $sn->pnullableint);
+    }
+
+    /**
+     * Test for "@var ?string" with string value
+     */
+    public function testMapSimpleNullableString()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullablestring":0}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertIsString($sn->pnullablestring);
+        $this->assertEquals("0", $sn->pnullablestring);
+    }
+
+    /**
+     * Test for "@var ?string" with null value
+     */
+    public function testMapSimpleNullableStringNull()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullablestring":null}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertNull($sn->pnullablestring);
+        $this->assertEquals(null, $sn->pnullablestring);
+    }
+
+    /**
+     * Test for "@var ?string" with string value
+     */
+    public function testMapSimpleNullableStringWrong()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullablestring":"test"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertIsString($sn->pnullablestring);
+        $this->assertEquals("test", $sn->pnullablestring);
     }
 
     /**

--- a/tests/support/JsonMapperTest/Simple.php
+++ b/tests/support/JsonMapperTest/Simple.php
@@ -43,7 +43,12 @@ class JsonMapperTest_Simple
     /**
      * @var int|null
      */
-    public $pnullable;
+    public $pnullableint;
+
+    /**
+     * @var ?string
+     */
+    public $pnullablestring;
 
     /**
      * @var float


### PR DESCRIPTION
I used the following syntax in my PHP class: `/** @var ?int */`
Which gave me the following error: `Class '?int' not found`
I changed it to the following, which does work: `/** @var int|null */`

It would be nice if JsonMapper supported both syntaxes. PhpStorm also supports this syntax. This merge request adds support for the shorter syntax.